### PR TITLE
Expand on remote access disabling

### DIFF
--- a/patches/disable-remote-access-by-default.patch
+++ b/patches/disable-remote-access-by-default.patch
@@ -1,8 +1,8 @@
 diff --git a/remoting/host/policy_watcher.cc b/remoting/host/policy_watcher.cc
-index 694f832b5f047..078e63cef135d 100644
+index 694f832b5f047..ab220a2f5cb74 100644
 --- a/remoting/host/policy_watcher.cc
 +++ b/remoting/host/policy_watcher.cc
-@@ -166,7 +166,7 @@ base::Value::Dict PolicyWatcher::GetPlatformPolicies() {
+@@ -166,13 +166,13 @@ base::Value::Dict PolicyWatcher::GetPlatformPolicies() {
  
  base::Value::Dict PolicyWatcher::GetDefaultPolicies() {
    base::Value::Dict result;
@@ -11,6 +11,13 @@ index 694f832b5f047..078e63cef135d 100644
    result.Set(key::kRemoteAccessHostClientDomainList, base::Value::List());
    result.Set(key::kRemoteAccessHostDomainList, base::Value::List());
    result.Set(key::kRemoteAccessHostAllowRelayedConnection, true);
+   result.Set(key::kRemoteAccessHostUdpPortRange, "");
+   result.Set(key::kRemoteAccessHostClipboardSizeBytes, -1);
+-  result.Set(key::kRemoteAccessHostAllowRemoteSupportConnections, true);
++  result.Set(key::kRemoteAccessHostAllowRemoteSupportConnections, false);
+ #if BUILDFLAG(IS_CHROMEOS)
+   result.Set(key::kRemoteAccessHostAllowEnterpriseRemoteSupportConnections,
+              true);
 @@ -188,7 +188,7 @@ base::Value::Dict PolicyWatcher::GetDefaultPolicies() {
    result.Set(key::kRemoteAccessHostAllowFileTransfer, true);
    result.Set(key::kRemoteAccessHostAllowUrlForwarding, true);


### PR DESCRIPTION
This disables remote support connections, which are considered different from regular remote access connections.