### PR TITLE
rewrite: Flag exposure

### DIFF
--- a/patches/add-incognito-launch-feature.patch
+++ b/patches/add-incognito-launch-feature.patch
@@ -1,0 +1,83 @@
+diff --git a/chrome/browser/prefs/incognito_mode_prefs.cc b/chrome/browser/prefs/incognito_mode_prefs.cc
+index 252de88cbf948..37116fc4fba56 100644
+--- a/chrome/browser/prefs/incognito_mode_prefs.cc
++++ b/chrome/browser/prefs/incognito_mode_prefs.cc
+@@ -17,6 +17,7 @@
+ #include "components/policy/core/common/policy_pref_names.h"
+ #include "components/pref_registry/pref_registry_syncable.h"
+ #include "components/prefs/pref_service.h"
++#include "chrome/common/chrome_features.cc"
+ 
+ #if BUILDFLAG(IS_WIN)
+ #include "chrome/browser/win/parental_controls.h"
+@@ -154,7 +155,8 @@ bool IncognitoModePrefs::ShouldLaunchIncognitoInternal(
+   // to launch in incognito mode or if it was forced via prefs. This way,
+   // the parental controls check (which can be quite slow) can be avoided
+   // most of the time.
+-  bool forced_by_switch = command_line.HasSwitch(switches::kIncognito);
++  bool forced_by_switch = command_line.HasSwitch(switches::kIncognito) ||
++		base::FeatureList::IsEnabled(features::kIncognitoLaunch);
+   if (for_subsequent_browsers) {
+     forced_by_switch =
+         forced_by_switch &&
+diff --git a/chrome/browser/ui/startup/startup_browser_creator.cc b/chrome/browser/ui/startup/startup_browser_creator.cc
+index 8740af9bc6cd6..0019f14966239 100644
+--- a/chrome/browser/ui/startup/startup_browser_creator.cc
++++ b/chrome/browser/ui/startup/startup_browser_creator.cc
+@@ -344,6 +344,7 @@ StartupProfileModeReason ShouldShowProfilePickerAtProcessLaunch(
+                                      g_browser_process->local_state(),
+                                      /*show_warning=*/false) ||
+       command_line.HasSwitch(switches::kIncognito) ||
++      base::FeatureList::IsEnabled(features::kIncognitoLaunch) ||
+       has_command_line_specified_profile_directory) {
+     // TODO(crbug.com/40257919): The profile directory and guest mode
+     // were already tested in the calling function `GetStartupProfilePath()`.
+@@ -421,7 +422,9 @@ Profile* GetPrivateProfileIfRequested(const base::CommandLine& command_line,
+                                                 profile->GetPrefs())) {
+     return profile->GetPrimaryOTRProfile(/*create_if_needed=*/true);
+   } else {
+-    bool expect_incognito = command_line.HasSwitch(switches::kIncognito);
++    bool expect_incognito = command_line.HasSwitch(switches::kIncognito) ||
++	                    base::FeatureList::IsEnabled(
++						features::kIncognitoLaunch);
+     LOG_IF(WARNING, expect_incognito)
+         << "Incognito mode disabled by policy, launching a normal "
+         << "browser session.";
+@@ -999,7 +1002,9 @@ bool StartupBrowserCreator::ProcessCmdLineImpl(
+       CanOpenProfileOnStartup(profile_info) && !should_launch_incognito;
+ 
+   RecordIncognitoForcedStart(should_launch_incognito,
+-                             command_line.HasSwitch(switches::kIncognito));
++                             command_line.HasSwitch(switches::kIncognito) ||
++			     base::FeatureList::IsEnabled(
++						features::kIncognitoLaunch));
+ 
+   // `profile` is never off-the-record. If Incognito or Guest enforcement switch
+   // or policy are provided, use the appropriate private browsing profile
+diff --git a/chrome/common/chrome_features.cc b/chrome/common/chrome_features.cc
+index f3224987d31d6..67a1a5ecf15e1 100644
+--- a/chrome/common/chrome_features.cc
++++ b/chrome/common/chrome_features.cc
+@@ -17,6 +17,9 @@ namespace features {
+ 
+ // All features in alphabetical order.
+ 
++BASE_FEATURE(kIncognitoLaunch, "IncognitoLaunch",
++	base::FEATURE_DISABLED_BY_DEFAULT);
++
+ #if BUILDFLAG(IS_CHROMEOS_ASH)
+ // If enabled device status collector will add the type of session (Affiliated
+ // User, Kiosks, Managed Guest Sessions) to the device status report.
+diff --git a/chrome/common/chrome_features.h b/chrome/common/chrome_features.h
+index fc691fad58cbd..6c506b3fc555a 100644
+--- a/chrome/common/chrome_features.h
++++ b/chrome/common/chrome_features.h
+@@ -25,6 +25,8 @@
+ 
+ namespace features {
+ 
++BASE_DECLARE_FEATURE(kIncognitoLaunch);
++
+ // All features in alphabetical order. The features should be documented
+ // alongside the definition of their values in the .cc file.
+ 

--- a/patches/expose-flags.patch
+++ b/patches/expose-flags.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
-index f705f4aa8b568..145eb17541758 100644
+index 96370d4ac35a9..bc80527377261 100644
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -4133,6 +4133,26 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -4190,6 +4190,35 @@ const FeatureEntry kFeatureEntries[] = {
  // //tools/flags/generate_unexpire_flags.py.
  #include "build/chromeos_buildflags.h"
  #include "chrome/browser/unexpire_flags_gen.inc"
@@ -10,80 +10,31 @@ index f705f4aa8b568..145eb17541758 100644
 +     "Incognito Launch",
 +     "Incognito mode on launch. This flag is exposed by hardened-chromium.",
 +     kOsAll, SINGLE_VALUE_TYPE("incognito")},
++    {"disable-extensions",
++     "Disable Extensions",
++     "Disables extensions support. This flag is exposed by hardened-chromium.",
++     kOsAll, SINGLE_VALUE_TYPE("disable-extensions")},
 +    {"disable-cross-origin-referrers",
-+     flag_descriptions::kDisableCrossOriginReferrersName,
-+     flag_descriptions::kDisableCrossOriginReferrersDescription, kOsAll,
++     "Clear cross-origin referrers",
++     "Clears referrers when navigating across origins. Defaults to disabled. "
++     "This feature is provided by hardened-chromium.", kOsAll,
 +     FEATURE_VALUE_TYPE(net::features::kDisableCrossOriginReferrers)},
 +    {"cross-origin-trim-referrer",
-+     flag_descriptions::kCapReferrerToOriginOnCrossOriginName,
-+     flag_descriptions::kCapReferrerToOriginOnCrossOriginDescription, kOsAll,
++     "Cross-origin referrer trimming",
++     "Trims the referrer to just the origin on cross origin navigation. "
++     "Defaults to enabled. This feature is exposed by hardened-chromium.",
++     kOsAll,
 +     FEATURE_VALUE_TYPE(net::features::kCapReferrerToOriginOnCrossOrigin)},
 +    {"hide-profile-icon",
-+     flag_descriptions::kHideProfileIconName,
-+     flag_descriptions::kHideProfileIconDescription, kOsAll,
++     "Hide profile icon in toolbar",
++     "Hides the profile icon in the toolbar in regular profiles. Defaults "
++     "to enabled. This feature is provided by hardened-chromium." , kOsAll,
 +     FEATURE_VALUE_TYPE(features::kHideProfileIcon)},
 +    {"show-punycode-domains",
-+     flag_descriptions::kShowPunycodeDomainsName,
-+     flag_descriptions::kShowPunycodeDomainsDescription, kOsAll,
-+     FEATURE_VALUE_TYPE(url::kShowPunycodeDomains)},
++     "Show punycode for IDN domains",
++     "Shows punycode for IDN domains to mitigate IDN homograph attacks. "
++     "Defaults to disabled. This feature is provided by hardened-chromium.",
++     kOsAll, FEATURE_VALUE_TYPE(url::kShowPunycodeDomains)},
      {variations::switches::kEnableBenchmarking,
       flag_descriptions::kEnableBenchmarkingName,
       flag_descriptions::kEnableBenchmarkingDescription, kOsAll,
-diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
-index 695e4f8ba74d0..b82fdbd37d370 100644
---- a/chrome/browser/flag_descriptions.cc
-+++ b/chrome/browser/flag_descriptions.cc
-@@ -14,6 +14,28 @@
- 
- namespace flag_descriptions {
- 
-+const char kDisableCrossOriginReferrersName[] =
-+    "Clear cross-origin referrers";
-+const char kDisableCrossOriginReferrersDescription[] =
-+    "Clears referrers when navigating across origins. Defaults to disabled. "
-+    "This feature is provided by hardened-chromium.";
-+
-+const char kCapReferrerToOriginOnCrossOriginName[] =
-+    "Cross-origin referrer trimming";
-+const char kCapReferrerToOriginOnCrossOriginDescription[] =
-+    "Trims the referrer to just the origin on cross origin navigation. "
-+    "Defaults to enabled. This feature is exposed by hardened-chromium.";
-+
-+const char kHideProfileIconName[] = "Hide profile icon in toolbar";
-+const char kHideProfileIconDescription[] =
-+    "Hides the profile icon in the toolbar in regular profiles. Defaults "
-+    "to enabled. This feature is provided by hardened-chromium.";
-+
-+const char kShowPunycodeDomainsName[] = "Show punycode for IDN domains";
-+const char kShowPunycodeDomainsDescription[] =
-+    "Shows punycode for IDN domains to mitigate IDN homograph attacks. "
-+    "Defaults to disabled. This feature is provided by hardened-chromium.";
-+
- const char kAccelerated2dCanvasName[] = "Accelerated 2D canvas";
- const char kAccelerated2dCanvasDescription[] =
-     "Enables the use of the GPU to perform 2d canvas rendering instead of "
-diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
-index 83c2d22343339..ef1975e1ea895 100644
---- a/chrome/browser/flag_descriptions.h
-+++ b/chrome/browser/flag_descriptions.h
-@@ -43,6 +43,20 @@
- 
- namespace flag_descriptions {
- 
-+// hardened chromium ----------------------------------------------------------
-+
-+extern const char kDisableCrossOriginReferrersName[];
-+extern const char kDisableCrossOriginReferrersDescription[];
-+
-+extern const char kCapReferrerToOriginOnCrossOriginName[];
-+extern const char kCapReferrerToOriginOnCrossOriginDescription[];
-+
-+extern const char kHideProfileIconName[];
-+extern const char kHideProfileIconDescription[];
-+
-+extern const char kShowPunycodeDomainsName[];
-+extern const char kShowPunycodeDomainsDescription[];
-+
- // Cross-platform -------------------------------------------------------------
- 
- extern const char kAccelerated2dCanvasName[];

--- a/patches/expose-flags.patch
+++ b/patches/expose-flags.patch
@@ -2,18 +2,19 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 index 96370d4ac35a9..bc80527377261 100644
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -4190,6 +4190,35 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -4190,6 +4190,36 @@ const FeatureEntry kFeatureEntries[] = {
  // //tools/flags/generate_unexpire_flags.py.
  #include "build/chromeos_buildflags.h"
  #include "chrome/browser/unexpire_flags_gen.inc"
 +    {"incognito-launch",
 +     "Incognito Launch",
-+     "Incognito mode on launch. This flag is exposed by hardened-chromium.",
-+     kOsAll, SINGLE_VALUE_TYPE("incognito")},
-+    {"disable-extensions",
-+     "Disable Extensions",
-+     "Disables extensions support. This flag is exposed by hardened-chromium.",
-+     kOsAll, SINGLE_VALUE_TYPE("disable-extensions")},
++     "Launch external links and open new sessions in Incognito. Disabled by "
++     "default. This flag is provided by hardened-chromium.",
++     kOsAll, FEATURE_VALUE_TYPE(features::kIncognitoLaunch)},
++    {"extensions-support",
++     "Extensions Support",
++     "Toggle extensions support. This flag is exposed by hardened-chromium.",
++     kOsAll, SINGLE_DISABLE_VALUE_TYPE("disable-extensions")},
 +    {"disable-cross-origin-referrers",
 +     "Clear cross-origin referrers",
 +     "Clears referrers when navigating across origins. Defaults to disabled. "


### PR DESCRIPTION
Rewrote flag exposure patch to be smaller and easier to read and modify, it was needlessly big to patch 2 extra files for names and descriptions.
Rewrote Incognito launch to be more consistent, in line with intended behavior. (Behavior described in flag description)
Added flag to disable extensions support. (This will not remove extensions should it be enabled, this is not enabled by default)