### PR TITLE
Revert "feat: Remove reference to removed preferences"

### DIFF
--- a/patches/remove-unused-preferences.patch
+++ b/patches/remove-unused-preferences.patch
@@ -1,16 +1,3 @@
-diff --git a/chrome/browser/resources/settings/basic_page/basic_page.html b/chrome/browser/resources/settings/basic_page/basic_page.html
-index f44cde44ed34f..361492b4390c7 100644
---- a/chrome/browser/resources/settings/basic_page/basic_page.html
-+++ b/chrome/browser/resources/settings/basic_page/basic_page.html
-@@ -17,7 +17,7 @@
-           </settings-reset-profile-banner>
-         </template>
-         <template is="dom-if" if="[[showPage_(pageVisibility.people)]]" restamp>
--          <settings-section page-title="$i18n{peoplePageTitle}"
-+          <settings-section page-title="$i18n{profileInformationTitle}"
-               section="people">
-             <settings-people-page prefs="{{prefs}}"
-                 page-visibility="[[pageVisibility]]">
 diff --git a/chrome/browser/resources/settings/basic_page/basic_page.ts b/chrome/browser/resources/settings/basic_page/basic_page.ts
 index 1024f4f8206f6..a3f1a384030c2 100644
 --- a/chrome/browser/resources/settings/basic_page/basic_page.ts
@@ -42,19 +29,6 @@ index 6297480d4f357..16514e7c58c5e 100644
  
  <if expr="not chromeos_ash">
          <template is="dom-if" if="[[signinAllowed_]]">
-diff --git a/chrome/browser/resources/settings/privacy_page/privacy_page.html b/chrome/browser/resources/settings/privacy_page/privacy_page.html
-index af9ea12b78f9f..c197d054668d7 100644
---- a/chrome/browser/resources/settings/privacy_page/privacy_page.html
-+++ b/chrome/browser/resources/settings/privacy_page/privacy_page.html
-@@ -86,7 +86,7 @@
-         </template>
-         <cr-link-row id="securityLinkRow" start-icon="settings:lock-outline"
-             class="hr" label="$i18n{securityPageTitle}"
--            sub-label="$i18n{securityPageDescription}"
-+            sub-label="$i18n{privacyGuidePromoBody}"
-             on-click="onSecurityPageClick_"
-             role-description="$i18n{subpageArrowRoleDescription}"></cr-link-row>
-         <cr-link-row id="permissionsLinkRow" start-icon="settings:permissions"
 diff --git a/chrome/browser/resources/settings/privacy_page/privacy_page.ts b/chrome/browser/resources/settings/privacy_page/privacy_page.ts
 index 00318322c8147..b89acab52a96a 100644
 --- a/chrome/browser/resources/settings/privacy_page/privacy_page.ts
@@ -70,10 +44,10 @@ index 00318322c8147..b89acab52a96a 100644
  
    // Only show Manage Topics page when PTB is enabled. If user is part of Mode B
 diff --git a/chrome/browser/resources/settings/privacy_page/security_page.html b/chrome/browser/resources/settings/privacy_page/security_page.html
-index 8fd4f50e2d484..21efc5e3a7942 100644
+index 8fd4f50e2d484..39db730a58b76 100644
 --- a/chrome/browser/resources/settings/privacy_page/security_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/security_page.html
-@@ -64,204 +64,6 @@
+@@ -64,201 +64,6 @@
          pointer-events: auto;
        }
      </style>
@@ -272,13 +246,10 @@ index 8fd4f50e2d484..21efc5e3a7942 100644
 -        </settings-collapse-radio-button>
 -      </settings-radio-group>
 -    </div>
--    <div class="cr-row first">
--      <h2>$i18n{advancedPageTitle}</h2>
--    </div>
-     <template is="dom-if" if="[[!enableHttpsFirstModeNewSettings_]]">
-       <settings-toggle-button id="httpsOnlyModeToggle"
-           pref="{{prefs.generated.https_first_mode_enabled}}"
-@@ -400,18 +202,3 @@
+     <div class="cr-row first">
+       <h2>$i18n{advancedPageTitle}</h2>
+     </div>
+@@ -400,18 +205,3 @@
            on-click="onChromeCertificatesClick_">
        </cr-link-row>
  </if>
@@ -312,19 +283,6 @@ index 8fc6a6ae3a42a..df9ee0d5ccc19 100644
      // Initialize the last focus time on page load.
      this.lastFocusTime_ = HatsBrowserProxyImpl.getInstance().now();
    }
-diff --git a/chrome/browser/resources/settings/settings_menu/settings_menu.html b/chrome/browser/resources/settings/settings_menu/settings_menu.html
-index 658110a4a8775..0025ddee63361 100644
---- a/chrome/browser/resources/settings/settings_menu/settings_menu.html
-+++ b/chrome/browser/resources/settings/settings_menu/settings_menu.html
-@@ -54,7 +54,7 @@
- <if expr="_google_chrome">
-           <iron-icon icon="settings-internal:google-g"></iron-icon>
- </if>
--          $i18n{peoplePageTitle}
-+          $i18n{profileInformationTitle}
-           <cr-ripple></cr-ripple>
-         </a>
-         <a role="menuitem" id="autofill" href="/autofill"
 diff --git a/chrome/browser/ui/webui/settings/settings_ui.cc b/chrome/browser/ui/webui/settings/settings_ui.cc
 index 576fb73c196ec..67e6dbc4c54c5 100644
 --- a/chrome/browser/ui/webui/settings/settings_ui.cc


### PR DESCRIPTION
Reverts secureblue/hardened-chromium#63

Current version of patches causes a crash when opening the settings page.