### PR TITLE
feat: dynamically set GPU variable in chromium.conf

### DIFF
--- a/build/chromium.conf
+++ b/build/chromium.conf
@@ -3,7 +3,12 @@
 ARCH="$(arch)"
 
 # GRAPHIC_DRIVER=[amd|intel|nvidia|default]
-GRAPHIC_DRIVER=default
+GPU_INFO=$(lspci | grep -E "VGA|3D" | grep -o -i -E "amd|intel|nvidia" | sort -u | tr '[:upper:]' '[:lower:]' | xargs)
+if [ $(echo "$GPU_INFO" | wc -w) -gt 1 ]; then
+    GRAPHIC_DRIVER="default"
+else
+    GRAPHIC_DRIVER=${GPU_INFO:-default}
+fi
 
 # WEB_DARKMODE=[on|off]
 WEB_DARKMODE=off


### PR DESCRIPTION
different take on https://github.com/secureblue/hardened-chromium/pull/92 that doesn't require egl-utils and should better handle multi-gpu

If there are heterogeneous GPU vendors, it will fallback to default.

[This comment](https://github.com/secureblue/hardened-chromium/pull/92#issuecomment-2417220904) about the vulkan flags being experimental is worth heeding, although if they are experimental then it should at least be marked as such, or revised to work as expected.