### PR TITLE
feat: Exposed Preferences

### DIFF
--- a/patches/default-disable-3d-apis.patch
+++ b/patches/default-disable-3d-apis.patch
@@ -8,6 +8,6 @@ index bfbdf8fcc8fa0..fac996b413b3f 100644
      user_prefs::PrefRegistrySyncable* registry) {
 -  registry->RegisterBooleanPref(prefs::kDisable3DAPIs, false);
 +  registry->RegisterBooleanPref(prefs::kDisable3DAPIs, true);
-   registry->RegisterBooleanPref(prefs::kEnableHyperlinkAuditing, true);
+   registry->RegisterBooleanPref(prefs::kEnableHyperlinkAuditing, false);
    // Register user prefs for mapping SitePerProcess and IsolateOrigins in
    // user policy in addition to the same named ones in Local State (which are

--- a/patches/default-disable-3d-apis.patch
+++ b/patches/default-disable-3d-apis.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
+index bfbdf8fcc8fa0..fac996b413b3f 100644
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -1581,7 +1581,7 @@ void ChromeContentBrowserClient::RegisterLocalStatePrefs(
+ // static
+ void ChromeContentBrowserClient::RegisterProfilePrefs(
+     user_prefs::PrefRegistrySyncable* registry) {
+-  registry->RegisterBooleanPref(prefs::kDisable3DAPIs, false);
++  registry->RegisterBooleanPref(prefs::kDisable3DAPIs, true);
+   registry->RegisterBooleanPref(prefs::kEnableHyperlinkAuditing, true);
+   // Register user prefs for mapping SitePerProcess and IsolateOrigins in
+   // user policy in addition to the same named ones in Local State (which are

--- a/patches/disable-extensions-by-default.patch
+++ b/patches/disable-extensions-by-default.patch
@@ -2,22 +2,12 @@ diff --git a/chrome/browser/profiles/profile.cc b/chrome/browser/profiles/profil
 index 89254771117da..411ef3dfa5908 100644
 --- a/chrome/browser/profiles/profile.cc
 +++ b/chrome/browser/profiles/profile.cc
-@@ -42,6 +42,7 @@
- #include "content/public/browser/web_contents.h"
- #include "content/public/browser/web_ui.h"
- #include "extensions/buildflags/buildflags.h"
-+#include "base/command_line.h"
- 
- #if BUILDFLAG(IS_CHROMEOS)
- #include "ash/constants/ash_switches.h"
-@@ -321,7 +322,9 @@ void Profile::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+@@ -321,7 +321,7 @@ void Profile::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
    registry->RegisterIntegerPref(prefs::kContextualSearchPromoCardShownCount, 0);
  #endif  // BUILDFLAG(IS_ANDROID)
    registry->RegisterStringPref(prefs::kSessionExitType, std::string());
 -  registry->RegisterBooleanPref(prefs::kDisableExtensions, false);
-+  registry->RegisterBooleanPref(prefs::kDisableExtensions, !(base::CommandLine::
-+                                ForCurrentProcess()->HasSwitch(
-+                                                     "enable-extensions")));
++  registry->RegisterBooleanPref(prefs::kDisableExtensions, true);
  #if BUILDFLAG(ENABLE_EXTENSIONS)
    registry->RegisterBooleanPref(extensions::pref_names::kAlertsInitialized,
                                  false);

--- a/patches/expose-flags.patch
+++ b/patches/expose-flags.patch
@@ -1,38 +1,36 @@
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
-index ad599311ac46d..0f57380771272 100644
+index 9d0181f447a1a..8e10017c678f9 100644
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -4237,7 +4237,37 @@ const FeatureEntry kFeatureEntries[] = {
- // Include generated flags for flag unexpiry; see //docs/flag_expiry.md and
+@@ -4220,6 +4220,36 @@ const FeatureEntry kFeatureEntries[] = {
  // //tools/flags/generate_unexpire_flags.py.
  #include "build/chromeos_buildflags.h"
--#include "chrome/browser/unexpire_flags_gen.inc"
-+#include "chrome/browser/unexpire_flags_gen.inc",
+ #include "chrome/browser/unexpire_flags_gen.inc"
 +    {"incognito-launch", "Incognito Launch",
 +     "Launch external links and open new sessions in Incognito. Disabled by "
 +     "default. This feature is provided by hardened-chromium.",
 +     kOsAll, FEATURE_VALUE_TYPE(features::kIncognitoLaunch)},
++    {"show-punycode-domains", "Show punycode for IDN domains",
++     "Shows punycode for IDN domains to mitigate IDN homograph attacks. "
++     "Defaults to disabled. This feature is provided by hardened-chromium.",
++     kOsAll, FEATURE_VALUE_TYPE(url::kShowPunycodeDomains)},
 +    {"disable-cross-origin-referrers", "Clear cross-origin referrers",
-+     "Clears referrers when navigating across origins. Disabled by default. "
++     "Clears referrers when navigating across origins. Defaults to disabled. "
 +     "This feature is provided by hardened-chromium.", kOsAll,
 +     FEATURE_VALUE_TYPE(net::features::kDisableCrossOriginReferrers)},
 +    {"cross-origin-trim-referrer", "Cross-origin referrer trimming",
 +     "Trims the referrer to just the origin on cross origin navigation. "
-+     "Enabled by default. This feature is exposed by hardened-chromium.",
++     "Defaults to enabled. This feature is exposed by hardened-chromium.",
 +     kOsAll,
 +     FEATURE_VALUE_TYPE(net::features::kCapReferrerToOriginOnCrossOrigin)},
-+    {"show-punycode-domains", "Show punycode for IDN domains",
-+     "Shows punycode for IDN domains to mitigate IDN homograph attacks. "
-+     "Disabled by default. This feature is provided by hardened-chromium.",
-+     kOsAll, FEATURE_VALUE_TYPE(url::kShowPunycodeDomains)},
 +    {"hide-profile-icon", "Hide profile icon in toolbar",
-+     "Hides the profile icon in the toolbar in regular profiles. Enabled "
-+     "by default. This feature is provided by hardened-chromium." , kOsAll,
++     "Hides the profile icon in the toolbar in regular profiles. Defaults "
++     "to enabled. This feature is provided by hardened-chromium." , kOsAll,
 +     FEATURE_VALUE_TYPE(features::kHideProfileIcon)},
 +    {"disable-internal-page-jit", "Disable Internal Page Jit",
-+     "Disable JIT for JavaScript and WASM on internal pages. Enabled by "
-+     "default. This feature is provided by hardened-chromium.",
-+     kOsAll, FEATURE_VALUE_TYPE(features::kDisableInternalPageJit)}
++     "Disable JIT for JavaScript and WASM on internal pages & extensions. "
++     "Enabled by default. This feature is provided by hardened-chromium.",
++     kOsAll, FEATURE_VALUE_TYPE(features::kDisableInternalPageJit)},
 +    {"enable-gssapi", "Enable GSSAPI Authentication",
 +     "Enables GSSAPI for authentication. WARNING! This can cause the "
 +     "network service sandbox to become persistently disabled, enable only "

--- a/patches/expose-flags.patch
+++ b/patches/expose-flags.patch
@@ -1,39 +1,38 @@
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
-index 9d0181f447a1a..8e10017c678f9 100644
+index ad599311ac46d..0f57380771272 100644
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -4220,6 +4220,39 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -4237,7 +4237,37 @@ const FeatureEntry kFeatureEntries[] = {
+ // Include generated flags for flag unexpiry; see //docs/flag_expiry.md and
  // //tools/flags/generate_unexpire_flags.py.
  #include "build/chromeos_buildflags.h"
- #include "chrome/browser/unexpire_flags_gen.inc"
-+    {"disable-internal-page-jit", "Disable Internal Page Jit",
-+     "Disable JIT for JavaScript and WASM on internal pages. Enabled by "
-+     "default. This feature is provided by hardened-chromium.",
-+     kOsAll, FEATURE_VALUE_TYPE(features::kDisableInternalPageJit)},
+-#include "chrome/browser/unexpire_flags_gen.inc"
++#include "chrome/browser/unexpire_flags_gen.inc",
 +    {"incognito-launch", "Incognito Launch",
 +     "Launch external links and open new sessions in Incognito. Disabled by "
 +     "default. This feature is provided by hardened-chromium.",
 +     kOsAll, FEATURE_VALUE_TYPE(features::kIncognitoLaunch)},
 +    {"disable-cross-origin-referrers", "Clear cross-origin referrers",
-+     "Clears referrers when navigating across origins. Defaults to disabled. "
++     "Clears referrers when navigating across origins. Disabled by default. "
 +     "This feature is provided by hardened-chromium.", kOsAll,
 +     FEATURE_VALUE_TYPE(net::features::kDisableCrossOriginReferrers)},
 +    {"cross-origin-trim-referrer", "Cross-origin referrer trimming",
 +     "Trims the referrer to just the origin on cross origin navigation. "
-+     "Defaults to enabled. This feature is exposed by hardened-chromium.",
++     "Enabled by default. This feature is exposed by hardened-chromium.",
 +     kOsAll,
 +     FEATURE_VALUE_TYPE(net::features::kCapReferrerToOriginOnCrossOrigin)},
-+    {"hide-profile-icon", "Hide profile icon in toolbar",
-+     "Hides the profile icon in the toolbar in regular profiles. Defaults "
-+     "to enabled. This feature is provided by hardened-chromium." , kOsAll,
-+     FEATURE_VALUE_TYPE(features::kHideProfileIcon)},
 +    {"show-punycode-domains", "Show punycode for IDN domains",
 +     "Shows punycode for IDN domains to mitigate IDN homograph attacks. "
-+     "Defaults to disabled. This feature is provided by hardened-chromium.",
++     "Disabled by default. This feature is provided by hardened-chromium.",
 +     kOsAll, FEATURE_VALUE_TYPE(url::kShowPunycodeDomains)},
-+    {"extensions-support", "Extensions Support",
-+     "Toggle extensions support. This switch is provided by hardened-chromium.",
-+     kOsAll, SINGLE_VALUE_TYPE("enable-extensions")},
++    {"hide-profile-icon", "Hide profile icon in toolbar",
++     "Hides the profile icon in the toolbar in regular profiles. Enabled "
++     "by default. This feature is provided by hardened-chromium." , kOsAll,
++     FEATURE_VALUE_TYPE(features::kHideProfileIcon)},
++    {"disable-internal-page-jit", "Disable Internal Page Jit",
++     "Disable JIT for JavaScript and WASM on internal pages. Enabled by "
++     "default. This feature is provided by hardened-chromium.",
++     kOsAll, FEATURE_VALUE_TYPE(features::kDisableInternalPageJit)}
 +    {"enable-gssapi", "Enable GSSAPI Authentication",
 +     "Enables GSSAPI for authentication. WARNING! This can cause the "
 +     "network service sandbox to become persistently disabled, enable only "

--- a/patches/user-preferences.patch
+++ b/patches/user-preferences.patch
@@ -55,7 +55,7 @@ index d54888d0e712f..00f7c8c080bce 100644
 +      pref="{{prefs.extensions.disabled}}"
 +      label="Disable Extensions"
 +    </settings-toggle-button>
-+    <settings-dropdown-menu id="webrtcHandlingPolicy"
++    <settings-dropdown-menu
 +      label="WebRTC Handling Policy"
 +      pref="{{prefs.webrtc.ip_handling_policy}}"
 +      menu-options="[[webrtcHandlingPolicyOptions_]]">
@@ -71,7 +71,7 @@ index b0371a95c7dbe..7e0062f524084 100644
        },
        // </if>
  
-+      referersPolicyOptions_: {
++      webrtcHandlingPolicyOptions_: {
 +        readOnly: true,
 +        type: Array,
 +        value() {

--- a/patches/user-preferences.patch
+++ b/patches/user-preferences.patch
@@ -39,14 +39,12 @@ diff --git a/chrome/browser/resources/settings/privacy_page/security_page.html b
 index d54888d0e712f..00f7c8c080bce 100644
 --- a/chrome/browser/resources/settings/privacy_page/security_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/security_page.html
-@@ -77,6 +77,30 @@
+@@ -77,6 +77,28 @@
          pointer-events: auto;
        }
      </style>
-+    <div>
-+      <div class="cr-row first">
-+        <h2 class="cr-title-text">Privacy</h2>
-+      </div>
++    <div id="privacySection">
++      <h2 class="cr-title-text">Privacy</h2>
 +      <settings-toggle-button class="cr-row"
 +        pref="{{prefs.disable_3d_apis}}"
 +        label="Disable 3D APIs"

--- a/patches/user-preferences.patch
+++ b/patches/user-preferences.patch
@@ -49,11 +49,11 @@ index d54888d0e712f..00f7c8c080bce 100644
 +    <settings-toggle-button class="cr-row first"
 +      pref="{{prefs.disable_3d_apis}}"
 +      label="Disable 3D APIs"
-+      sub-label="Disable features like WebGL and Pepper 3D"
++      sub-label="Disable features like WebGL and Pepper 3D">
 +    </settings-toggle-button>
 +    <settings-toggle-button class="cr-row"
 +      pref="{{prefs.extensions.disabled}}"
-+      label="Disable Extensions"
++      label="Disable Extensions">
 +    </settings-toggle-button>
 +    <settings-dropdown-menu
 +      label="WebRTC Handling Policy"

--- a/patches/user-preferences.patch
+++ b/patches/user-preferences.patch
@@ -49,7 +49,7 @@ index d54888d0e712f..2dbeb7b8b444b 100644
  
        .bullet-line {
          align-items: center;
-@@ -227,3 +230,26 @@
+@@ -227,3 +230,27 @@
            on-click="onChromeCertificatesClick_">
        </cr-link-row>
  </if>
@@ -64,6 +64,7 @@ index d54888d0e712f..2dbeb7b8b444b 100644
 +      <settings-toggle-button class="cr-row"
 +        pref="{{prefs.extensions.disabled}}"
 +        label="Disable Extensions">
++        sub-label="Changes to this setting requires a restart">
 +      </settings-toggle-button>
 +      <div class="cr-row">
 +        <div id="webrtcLabel" class="flex cr-padded-text" aria-hidden="true">

--- a/patches/user-preferences.patch
+++ b/patches/user-preferences.patch
@@ -36,17 +36,27 @@ index 47120511edffd..53f2330898dd9 100644
              class="hr"
              hidden="[[!showHr_(
 diff --git a/chrome/browser/resources/settings/privacy_page/security_page.html b/chrome/browser/resources/settings/privacy_page/security_page.html
-index d54888d0e712f..a3e86c5beefd6 100644
+index d54888d0e712f..2dbeb7b8b444b 100644
 --- a/chrome/browser/resources/settings/privacy_page/security_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/security_page.html
-@@ -227,3 +227,32 @@
+@@ -7,6 +7,9 @@
+         padding: 0 var(--cr-section-padding);
+       }
+ 
++      #webrtcLabel {
++        flex: 1;
++      }
+ 
+       .bullet-line {
+         align-items: center;
+@@ -227,3 +230,26 @@
            on-click="onChromeCertificatesClick_">
        </cr-link-row>
  </if>
 +
 +    <div id="hardeningSection">
-+      <h2 class="cr-title-text">Hardening</h2>
-+      <settings-toggle-button class="cr-row"
++      <div class="cr-row first"><h2 class="cr-title-text">Hardening</h2></div>
++      <settings-toggle-button class="cr-row first"
 +        pref="{{prefs.disable_3d_apis}}"
 +        label="Disable 3D APIs"
 +        sub-label="Disable features like WebGL and Pepper 3D">
@@ -54,15 +64,9 @@ index d54888d0e712f..a3e86c5beefd6 100644
 +      <settings-toggle-button class="cr-row"
 +        pref="{{prefs.extensions.disabled}}"
 +        label="Disable Extensions">
-+        <template is="dom-if" if="[[shouldShowRestart_(
-+            prefs.extensions.disabled.value)]]">
-+          <cr-button on-click="onRestartClick_" slot="more-actions">
-+            $i18n{restart}
-+          </cr-button>
-+        </template>
 +      </settings-toggle-button>
 +      <div class="cr-row">
-+        <div aria-hidden="true">
++        <div id="webrtcLabel" class="flex cr-padded-text" aria-hidden="true">
 +          WebRTC Handling Policy
 +        </div>
 +        <settings-dropdown-menu
@@ -73,7 +77,7 @@ index d54888d0e712f..a3e86c5beefd6 100644
 +      </div>
 +    </div>
 diff --git a/chrome/browser/resources/settings/privacy_page/security_page.ts b/chrome/browser/resources/settings/privacy_page/security_page.ts
-index b0371a95c7dbe..7e0062f524084 100644
+index b0371a95c7dbe..60857ef0ee296 100644
 --- a/chrome/browser/resources/settings/privacy_page/security_page.ts
 +++ b/chrome/browser/resources/settings/privacy_page/security_page.ts
 @@ -111,6 +111,19 @@ export class SettingsSecurityPageElement extends

--- a/patches/user-preferences.patch
+++ b/patches/user-preferences.patch
@@ -61,11 +61,6 @@ index d54888d0e712f..2dbeb7b8b444b 100644
 +        label="Disable 3D APIs"
 +        sub-label="Disable features like WebGL and Pepper 3D">
 +      </settings-toggle-button>
-+      <settings-toggle-button class="cr-row"
-+        pref="{{prefs.extensions.disabled}}"
-+        label="Disable Extensions">
-+        sub-label="Changes to this setting requires a restart">
-+      </settings-toggle-button>
 +      <div class="cr-row">
 +        <div id="webrtcLabel" class="flex cr-padded-text" aria-hidden="true">
 +          WebRTC Handling Policy
@@ -76,6 +71,11 @@ index d54888d0e712f..2dbeb7b8b444b 100644
 +          menu-options="[[webrtcHandlingPolicyOptions_]]">
 +        </settings-dropdown-menu>
 +      </div>
++      <settings-toggle-button class="cr-row"
++        pref="{{prefs.extensions.disabled}}"
++        label="Disable Extensions">
++        sub-label="Changes to this setting requires a restart">
++      </settings-toggle-button>
 +    </div>
 diff --git a/chrome/browser/resources/settings/privacy_page/security_page.ts b/chrome/browser/resources/settings/privacy_page/security_page.ts
 index b0371a95c7dbe..60857ef0ee296 100644

--- a/patches/user-preferences.patch
+++ b/patches/user-preferences.patch
@@ -1,0 +1,87 @@
+diff --git a/chrome/browser/extensions/api/settings_private/prefs_util.cc b/chrome/browser/extensions/api/settings_private/prefs_util.cc
+index 9be2589cac759..be53fe96dd397 100644
+--- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
++++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
+@@ -172,6 +172,16 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetAllowlistedKeys() {
+   }
+   s_allowlist = new PrefsUtil::TypedPrefMap();
+ 
++  // hardened-chromium
++  (*s_allowlist)[::prefs::kWebRTCIPHandlingPolicy] =
++      settings_api::PrefType::kString;
++  (*s_allowlist)[::prefs::kDisable3DAPIs] =
++      settings_api::PrefType::kBoolean;
++  (*s_allowlist)[::prefs::kWebKitForceDarkModeEnabled] =
++      settings_api::PrefType::kBoolean;
++  (*s_allowlist)[::prefs::kDisableExtensions] =
++      settings_api::PrefType::kBoolean;
++
+   // Miscellaneous
+   (*s_allowlist)[::embedder_support::kAlternateErrorPagesEnabled] =
+       settings_api::PrefType::kBoolean;
+diff --git a/chrome/browser/resources/settings/appearance_page/appearance_page.html b/chrome/browser/resources/settings/appearance_page/appearance_page.html
+index 47120511edffd..acbcbfc8e4c1a 100644
+--- a/chrome/browser/resources/settings/appearance_page/appearance_page.html
++++ b/chrome/browser/resources/settings/appearance_page/appearance_page.html
+@@ -250,6 +250,11 @@
+             inverted>
+         </settings-toggle-button>
+ </if>
++        <div class="hr"></div>
++        <settings-toggle-button
++            pref="{{prefs.webkit.webprefs.force_dark_mode_enabled}}"
++            label="Website Dark Mode">
++        </settings-toggle-button>
+         <div class="cr-row">
+           <div class="flex cr-padded-text" aria-hidden="true">
+             $i18n{fontSize}
+diff --git a/chrome/browser/resources/settings/privacy_page/security_page.html b/chrome/browser/resources/settings/privacy_page/security_page.html
+index d54888d0e712f..00f7c8c080bce 100644
+--- a/chrome/browser/resources/settings/privacy_page/security_page.html
++++ b/chrome/browser/resources/settings/privacy_page/security_page.html
+@@ -77,6 +77,23 @@
+         pointer-events: auto;
+       }
+     </style>
++    <div class="cr-row first">
++      <h2 class="cr-title-text">Privacy</h2>
++    </div>
++    <settings-toggle-button class="cr-row first"
++      pref="{{prefs.disable_3d_apis}}"
++      label="Disable 3D APIs"
++      sub-label="Disable features like WebGL and Pepper 3D"
++    </settings-toggle-button>
++    <settings-toggle-button class="cr-row"
++      pref="{{prefs.extensions.disabled}}"
++      label="Disable Extensions"
++    </settings-toggle-button>
++    <settings-dropdown-menu id="webrtcHandlingPolicy"
++      label="WebRTC Handling Policy"
++      pref="{{prefs.webrtc.ip_handling_policy}}"
++      menu-options="[[webrtcHandlingPolicyOptions_]]">
++    </settings-dropdown-menu>
+     <template is="dom-if" if="[[enableHttpsFirstModeNewSettings_]]" restamp>
+       <div id="secureConnectionsSection">
+         <h2 class="cr-title-text">$i18n{secureConnectionsSectionTitle}</h2>
+diff --git a/chrome/browser/resources/settings/privacy_page/security_page.ts b/chrome/browser/resources/settings/privacy_page/security_page.ts
+index b0371a95c7dbe..7e0062f524084 100644
+--- a/chrome/browser/resources/settings/privacy_page/security_page.ts
++++ b/chrome/browser/resources/settings/privacy_page/security_page.ts
+@@ -111,6 +111,17 @@ export class SettingsSecurityPageElement extends
+       },
+       // </if>
+ 
++      referersPolicyOptions_: {
++        readOnly: true,
++        type: Array,
++        value() {
++          return [
++            {value: "default", name: loadTimeData.getString('default')},
++            {value: "disable_non_proxied_udp", name: loadTimeData.getString('disableNonProxiedUdp')},
++          ];
++        },
++      },
++
+       /**
+        * Whether the secure DNS setting should be displayed.
+        */

--- a/patches/user-preferences.patch
+++ b/patches/user-preferences.patch
@@ -20,31 +20,32 @@ index 9be2589cac759..be53fe96dd397 100644
    (*s_allowlist)[::embedder_support::kAlternateErrorPagesEnabled] =
        settings_api::PrefType::kBoolean;
 diff --git a/chrome/browser/resources/settings/appearance_page/appearance_page.html b/chrome/browser/resources/settings/appearance_page/appearance_page.html
-index 47120511edffd..acbcbfc8e4c1a 100644
+index 47120511edffd..53f2330898dd9 100644
 --- a/chrome/browser/resources/settings/appearance_page/appearance_page.html
 +++ b/chrome/browser/resources/settings/appearance_page/appearance_page.html
-@@ -250,6 +250,11 @@
-             inverted>
-         </settings-toggle-button>
- </if>
+@@ -119,6 +119,11 @@
+             </template>
+           </select>
+         </div>
 +        <div class="hr"></div>
 +        <settings-toggle-button
 +            pref="{{prefs.webkit.webprefs.force_dark_mode_enabled}}"
 +            label="Website Dark Mode">
 +        </settings-toggle-button>
-         <div class="cr-row">
-           <div class="flex cr-padded-text" aria-hidden="true">
-             $i18n{fontSize}
+         <div
+             class="hr"
+             hidden="[[!showHr_(
 diff --git a/chrome/browser/resources/settings/privacy_page/security_page.html b/chrome/browser/resources/settings/privacy_page/security_page.html
-index d54888d0e712f..00f7c8c080bce 100644
+index d54888d0e712f..a3e86c5beefd6 100644
 --- a/chrome/browser/resources/settings/privacy_page/security_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/security_page.html
-@@ -77,6 +77,28 @@
-         pointer-events: auto;
-       }
-     </style>
-+    <div id="privacySection">
-+      <h2 class="cr-title-text">Privacy</h2>
+@@ -227,3 +227,32 @@
+           on-click="onChromeCertificatesClick_">
+       </cr-link-row>
+ </if>
++
++    <div id="hardeningSection">
++      <h2 class="cr-title-text">Hardening</h2>
 +      <settings-toggle-button class="cr-row"
 +        pref="{{prefs.disable_3d_apis}}"
 +        label="Disable 3D APIs"
@@ -53,6 +54,12 @@ index d54888d0e712f..00f7c8c080bce 100644
 +      <settings-toggle-button class="cr-row"
 +        pref="{{prefs.extensions.disabled}}"
 +        label="Disable Extensions">
++        <template is="dom-if" if="[[shouldShowRestart_(
++            prefs.extensions.disabled.value)]]">
++          <cr-button on-click="onRestartClick_" slot="more-actions">
++            $i18n{restart}
++          </cr-button>
++        </template>
 +      </settings-toggle-button>
 +      <div class="cr-row">
 +        <div aria-hidden="true">
@@ -65,9 +72,6 @@ index d54888d0e712f..00f7c8c080bce 100644
 +        </settings-dropdown-menu>
 +      </div>
 +    </div>
-     <template is="dom-if" if="[[enableHttpsFirstModeNewSettings_]]" restamp>
-       <div id="secureConnectionsSection">
-         <h2 class="cr-title-text">$i18n{secureConnectionsSectionTitle}</h2>
 diff --git a/chrome/browser/resources/settings/privacy_page/security_page.ts b/chrome/browser/resources/settings/privacy_page/security_page.ts
 index b0371a95c7dbe..7e0062f524084 100644
 --- a/chrome/browser/resources/settings/privacy_page/security_page.ts
@@ -81,9 +85,9 @@ index b0371a95c7dbe..7e0062f524084 100644
 +        type: Array,
 +        value() {
 +          return [
-+            {value: "default", name: "Default"'},
-+            {value: "default_public_and_private_interfaces", name: "Default Public and Private Interfaces"'},
-+            {value: "default_public_interface_only", name: "Default Public Interface Only"'},
++            {value: "default", name: "Default"},
++            {value: "default_public_and_private_interfaces", name: "Default Public and Private Interfaces"},
++            {value: "default_public_interface_only", name: "Default Public Interface Only"},
 +            {value: "disable_non_proxied_udp", name: "Disable Non-Proxied UDP"},
 +          ];
 +        },

--- a/patches/user-preferences.patch
+++ b/patches/user-preferences.patch
@@ -39,27 +39,34 @@ diff --git a/chrome/browser/resources/settings/privacy_page/security_page.html b
 index d54888d0e712f..00f7c8c080bce 100644
 --- a/chrome/browser/resources/settings/privacy_page/security_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/security_page.html
-@@ -77,6 +77,23 @@
+@@ -77,6 +77,30 @@
          pointer-events: auto;
        }
      </style>
-+    <div class="cr-row first">
-+      <h2 class="cr-title-text">Privacy</h2>
++    <div>
++      <div class="cr-row first">
++        <h2 class="cr-title-text">Privacy</h2>
++      </div>
++      <settings-toggle-button class="cr-row"
++        pref="{{prefs.disable_3d_apis}}"
++        label="Disable 3D APIs"
++        sub-label="Disable features like WebGL and Pepper 3D">
++      </settings-toggle-button>
++      <settings-toggle-button class="cr-row"
++        pref="{{prefs.extensions.disabled}}"
++        label="Disable Extensions">
++      </settings-toggle-button>
++      <div class="cr-row">
++        <div aria-hidden="true">
++          WebRTC Handling Policy
++        </div>
++        <settings-dropdown-menu
++          label="WebRTC Handling Policy"
++          pref="{{prefs.webrtc.ip_handling_policy}}"
++          menu-options="[[webrtcHandlingPolicyOptions_]]">
++        </settings-dropdown-menu>
++      </div>
 +    </div>
-+    <settings-toggle-button class="cr-row first"
-+      pref="{{prefs.disable_3d_apis}}"
-+      label="Disable 3D APIs"
-+      sub-label="Disable features like WebGL and Pepper 3D">
-+    </settings-toggle-button>
-+    <settings-toggle-button class="cr-row"
-+      pref="{{prefs.extensions.disabled}}"
-+      label="Disable Extensions">
-+    </settings-toggle-button>
-+    <settings-dropdown-menu
-+      label="WebRTC Handling Policy"
-+      pref="{{prefs.webrtc.ip_handling_policy}}"
-+      menu-options="[[webrtcHandlingPolicyOptions_]]">
-+    </settings-dropdown-menu>
      <template is="dom-if" if="[[enableHttpsFirstModeNewSettings_]]" restamp>
        <div id="secureConnectionsSection">
          <h2 class="cr-title-text">$i18n{secureConnectionsSectionTitle}</h2>
@@ -67,7 +74,7 @@ diff --git a/chrome/browser/resources/settings/privacy_page/security_page.ts b/c
 index b0371a95c7dbe..7e0062f524084 100644
 --- a/chrome/browser/resources/settings/privacy_page/security_page.ts
 +++ b/chrome/browser/resources/settings/privacy_page/security_page.ts
-@@ -111,6 +111,17 @@ export class SettingsSecurityPageElement extends
+@@ -111,6 +111,19 @@ export class SettingsSecurityPageElement extends
        },
        // </if>
  
@@ -76,8 +83,10 @@ index b0371a95c7dbe..7e0062f524084 100644
 +        type: Array,
 +        value() {
 +          return [
-+            {value: "default", name: loadTimeData.getString('default')},
-+            {value: "disable_non_proxied_udp", name: loadTimeData.getString('disableNonProxiedUdp')},
++            {value: "default", name: "Default"'},
++            {value: "default_public_and_private_interfaces", name: "Default Public and Private Interfaces"'},
++            {value: "default_public_interface_only", name: "Default Public Interface Only"'},
++            {value: "disable_non_proxied_udp", name: "Disable Non-Proxied UDP"},
 +          ];
 +        },
 +      },


### PR DESCRIPTION
This adds a new section to the Security page labeled "Hardening" that allows the user to configure the state of 3D apis like WebGL, toggle extensions support, and control WebRTC IP Handling. It also adds a website force dark mode in the appearance settings.
This PR also disables 3D APIs by default and removes the previous extension support flag.
Closes #102 