### PR TITLE
feat: Adjust internal page jit

### DIFF
--- a/patches/disable-jit-for-internal-pages.patch
+++ b/patches/disable-jit-for-internal-pages.patch
@@ -2,13 +2,17 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
 index e5ce608907f72..09159a4e83115 100644
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -8013,9 +8013,6 @@ bool ChromeContentBrowserClient::IsJitDisabledForSite(
+@@ -8013,9 +8013,10 @@ bool ChromeContentBrowserClient::IsJitDisabledForSite(
                                           nullptr) == CONTENT_SETTING_BLOCK;
    }
  
 -  // Only disable JIT for web schemes.
++  // Force disable JIT for non-web schemes, file schemes, or extensions.
 -  if (!site_url.SchemeIsHTTPOrHTTPS())
++  if (!(site_url.SchemeIsHTTPOrHTTPS() && !site_url.SchemeIs("chrome-extension")
++      && !site_url.SchemeIsFile())
 -    return false;
++    return true;
  
    return (map && map->GetContentSetting(site_url, site_url,
                                          ContentSettingsType::JAVASCRIPT_JIT) ==

--- a/patches/disable-jit-for-internal-pages.patch
+++ b/patches/disable-jit-for-internal-pages.patch
@@ -2,18 +2,13 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
 index e5ce608907f72..09159a4e83115 100644
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -8013,9 +8013,12 @@ bool ChromeContentBrowserClient::IsJitDisabledForSite(
+@@ -8013,9 +8013,6 @@ bool ChromeContentBrowserClient::IsJitDisabledForSite(
                                           nullptr) == CONTENT_SETTING_BLOCK;
    }
  
 -  // Only disable JIT for web schemes.
 -  if (!site_url.SchemeIsHTTPOrHTTPS())
-+  // Disable JIT for non-web schemes.
-+  if (!site_url.SchemeIsHTTPOrHTTPS()) {
-+    if (!base::FeatureList::IsEnabled(features::kEnableInternalPageJit))
-+      return true;
-     return false;
-+  }
+-    return false;
  
    return (map && map->GetContentSetting(site_url, site_url,
                                          ContentSettingsType::JAVASCRIPT_JIT) ==
@@ -21,17 +16,7 @@ diff --git a/content/public/common/content_features.cc b/content/public/common/c
 index 2d95d5e1df911..e7a29a6687a07 100644
 --- a/content/public/common/content_features.cc
 +++ b/content/public/common/content_features.cc
-@@ -16,6 +16,9 @@
- 
- namespace features {
- 
-+BASE_FEATURE(kEnableInternalPageJit, "EnableInternalPageJit",
-+             base::FEATURE_DISABLED_BY_DEFAULT);
-+
- // All features in alphabetical order.
- 
- // Kill switch to guard additional security checks performed by the browser
-@@ -1067,7 +1070,7 @@ BASE_FEATURE(kDisableProcessReuse,
+@@ -1067,7 +1067,7 @@ BASE_FEATURE(kDisableProcessReuse,
  // This feature is only consulted in site-per-process mode.
  BASE_FEATURE(kSpareRendererForSitePerProcess,
               "SpareRendererForSitePerProcess",
@@ -40,16 +25,3 @@ index 2d95d5e1df911..e7a29a6687a07 100644
  
  // Controls whether site isolation should use origins instead of scheme and
  // eTLD+1.
-diff --git a/content/public/common/content_features.h b/content/public/common/content_features.h
-index a69dcd3b24015..2f6f3d9265bbf 100644
---- a/content/public/common/content_features.h
-+++ b/content/public/common/content_features.h
-@@ -21,6 +21,8 @@
- 
- namespace features {
- 
-+CONTENT_EXPORT BASE_DECLARE_FEATURE(kEnableInternalPageJit);
-+
- // BEFORE MODIFYING THIS FILE: If your feature is only used inside content/, add
- // your feature in `content/common/features.h` instead.
- 

--- a/patches/disable-jit-for-internal-pages.patch
+++ b/patches/disable-jit-for-internal-pages.patch
@@ -7,11 +7,11 @@ index e5ce608907f72..09159a4e83115 100644
    }
  
 -  // Only disable JIT for web schemes.
-+  // Force disable JIT for non-web schemes, file schemes, or extensions.
 -  if (!site_url.SchemeIsHTTPOrHTTPS())
+-    return false;
++  // Force disable JIT for non-web schemes, file schemes, or extensions.
 +  if (!(site_url.SchemeIsHTTPOrHTTPS() && !site_url.SchemeIs("chrome-extension")
 +      && !site_url.SchemeIsFile())
--    return false;
 +    return true;
  
    return (map && map->GetContentSetting(site_url, site_url,

--- a/patches/disable-jit-for-internal-pages.patch
+++ b/patches/disable-jit-for-internal-pages.patch
@@ -10,8 +10,8 @@ index e5ce608907f72..09159a4e83115 100644
 -  if (!site_url.SchemeIsHTTPOrHTTPS())
 -    return false;
 +  // Force disable JIT for non-web schemes, file schemes, or extensions.
-+  if (!(site_url.SchemeIsHTTPOrHTTPS() && !site_url.SchemeIsFile())
-+      && !site_url.SchemeIs("chrome-extension")
++  if (!(site_url.SchemeIsHTTPOrHTTPS() && !site_url.SchemeIsFile()
++      && !site_url.SchemeIs("chrome-extension"))
 +    return true;
  
    return (map && map->GetContentSetting(site_url, site_url,

--- a/patches/disable-jit-for-internal-pages.patch
+++ b/patches/disable-jit-for-internal-pages.patch
@@ -10,7 +10,7 @@ index e5ce608907f72..09159a4e83115 100644
 -  if (!site_url.SchemeIsHTTPOrHTTPS())
 -    return false;
 +  // Force disable JIT for non-web schemes, file schemes, or extensions.
-+  if (!(site_url.SchemeIsHTTPOrHTTPS() && !site_url.SchemeIsFile()
++  if (!site_url.SchemeIsHTTPOrHTTPS() && !site_url.SchemeIsFile()
 +      && !site_url.SchemeIs("chrome-extension"))
 +    return true;
  

--- a/patches/disable-jit-for-internal-pages.patch
+++ b/patches/disable-jit-for-internal-pages.patch
@@ -9,7 +9,7 @@ index e5ce608907f72..09159a4e83115 100644
 -  // Only disable JIT for web schemes.
 -  if (!site_url.SchemeIsHTTPOrHTTPS())
 -    return false;
-+  // Force disable JIT for non-web schemes, file schemes, or extensions.
++  // Only force disable JIT for pages that aren't web schemes, aren't file schemes, and aren't extensions
 +  if (!site_url.SchemeIsHTTPOrHTTPS() && !site_url.SchemeIsFile()
 +      && !site_url.SchemeIs("chrome-extension"))
 +    return true;

--- a/patches/disable-jit-for-internal-pages.patch
+++ b/patches/disable-jit-for-internal-pages.patch
@@ -10,8 +10,8 @@ index e5ce608907f72..09159a4e83115 100644
 -  if (!site_url.SchemeIsHTTPOrHTTPS())
 -    return false;
 +  // Force disable JIT for non-web schemes, file schemes, or extensions.
-+  if (!(site_url.SchemeIsHTTPOrHTTPS() && !site_url.SchemeIs("chrome-extension")
-+      && !site_url.SchemeIsFile())
++  if (!(site_url.SchemeIsHTTPOrHTTPS() && !site_url.SchemeIsFile())
++      && !site_url.SchemeIs("chrome-extension")
 +    return true;
  
    return (map && map->GetContentSetting(site_url, site_url,

--- a/patches/expose-flags.patch
+++ b/patches/expose-flags.patch
@@ -2,7 +2,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 index 7613006656aaa..ee707f847ccba 100644
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -4343,6 +4343,44 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -4343,6 +4343,40 @@ const FeatureEntry kFeatureEntries[] = {
  // //tools/flags/generate_unexpire_flags.py.
  #include "build/chromeos_buildflags.h"
  #include "chrome/browser/unexpire_flags_gen.inc"
@@ -35,10 +35,6 @@ index 7613006656aaa..ee707f847ccba 100644
 +     "Hides the profile icon in the toolbar in regular profiles. Enabled "
 +     "by default. This feature is provided by Trivalent." , kOsAll,
 +     FEATURE_VALUE_TYPE(features::kHideProfileIcon)},
-+    {"internal-page-jit", "Internal Page Jit",
-+     "Toggle JIT for JavaScript and WASM on internal pages & extensions. "
-+     "Disabled by default. This feature is provided by Trivalent.",
-+     kOsAll, FEATURE_VALUE_TYPE(features::kEnableInternalPageJit)},
 +    {"gssapi-support", "GSSAPI Authentication",
 +     "Enables GSSAPI for authentication. WARNING! This can cause the "
 +     "network service sandbox to become persistently disabled, enable only "


### PR DESCRIPTION
This allows globally allowing JIT (even internal pages) and per-extension exceptions without needing to restart the browser