### PR TITLE
chore: Create trivalent-manpage.patch

### DIFF
--- a/patches/trivalent-manpage.patch
+++ b/patches/trivalent-manpage.patch
@@ -1,0 +1,49 @@
+Copyright 2024-2025 The Trivalent Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+---
+diff --git a/chrome/app/resources/manpage.1.in b/chrome/app/resources/manpage.1.in
+index ee15b8712b..1d79b2a99e 100644
+--- a/chrome/app/resources/manpage.1.in
++++ b/chrome/app/resources/manpage.1.in
+@@ -3,17 +3,13 @@
+ .TH @@PACKAGE@@ 1 "" "" "USER COMMANDS"
+ 
+ .SH NAME
+-@@PACKAGE@@ \- the web browser from Google
++@@PACKAGE@@ \- the web browser for secureblue
+ 
+ .SH SYNOPSIS
+ .B @@PACKAGE@@
+ [\fIOPTION\fR] [\fIPATH\fR|\fIURL\fR]
+ 
+ .SH DESCRIPTION
+-See the Google Chrome help center for help on using the browser.
+-.IP
+-<https://support.google.com/chrome/>
+-.PP
+ This manpage only describes invocation, environment, and arguments.
+ 
+ .SH OPTIONS
+@@ -156,10 +152,9 @@ Default directory for cache data.  (Why?  See
+ .SH BUGS
+ Bug tracker:
+ .IP
+-http://code.google.com/p/chromium/issues/list
++https://github.com/secureblue/trivalent/issues
+ .PP
+-Be sure to do your search within "All Issues" before reporting bugs,
+-and be sure to pick the "Defect on Linux" template when filing a new one.
++Be sure to do your search within open and closed issues before reporting bugs.
+ 
+ .SH AUTHOR
+-The Chromium team \- <http://www.chromium.org>
++The Trivalent team \- <http://github.com/secureblue/trivalent>


### PR DESCRIPTION
Chromium has a manpage for the browser, the manpage we were using was still referring to Google