### PR TITLE
chore: Revert "chore(build): switch back to github large runners unti…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     if: github.triggering_actor == 'royaloughtness'
     timeout-minutes: 180
     needs: buildsrpm
-    runs-on: ${{ inputs.arch == 'x86_64' && 'ubuntu-24.04-64core' || 'ubuntu-24.04-arm-64core' }}
+    runs-on: ${{ inputs.arch == 'x86_64' && 'blacksmith-32vcpu-ubuntu-2404' || 'blacksmith-32vcpu-ubuntu-2404-arm' }}
     container: 
       image: ${{ inputs.arch == 'x86_64' && 'fedora:42@sha256:89ed3ea10de7194c36524a290665960ddd4dae876a40beeadde2a9b4a0276681' || 'fedora:42@sha256:b6e8a32686d8bbe7a7e562d7215272a9b96b44c40e37f561ef807d112fde45d0' }}
       options: --privileged


### PR DESCRIPTION
…l blacksmith is fixed (#439)"

This reverts commit ef903ee0e188d6ec2a70311f1b8bae9cba5699ba.