### PR TITLE
fix: restore broken icons when using GTK frontend

### DIFF
--- a/build/trivalent.sh
+++ b/build/trivalent.sh
@@ -79,8 +79,8 @@ exec 2> >(exec cat >&2)
 # If ld.so.preload is readable, it may be used to preload into the browser which we don't want
 if [[ -r "/etc/ld.so.preload" ]]; then
   # shellcheck disable=SC2086
-  exec bwrap --dev-bind / / --ro-bind-try /dev/null /etc/ld.so.preload "$HERE/$CHROMIUM_NAME" $CHROMIUM_FLAGS "$@"
+  exec bwrap --dev-bind / / --ro-bind-try /dev/null /etc/ld.so.preload --setenv GDK_DISABLE icon-nodes "$HERE/$CHROMIUM_NAME" $CHROMIUM_FLAGS "$@"
 else
   # shellcheck disable=SC2086
-  exec -a "$0" "$HERE/$CHROMIUM_NAME" $CHROMIUM_FLAGS "$@"
+  GDK_DISABLE=icon-nodes exec -a "$0" "$HERE/$CHROMIUM_NAME" $CHROMIUM_FLAGS "$@"
 fi


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/glycin/-/issues/209#note_2592594