### PR TITLE
feat(conf): Extra conf files support

### DIFF
--- a/build/trivalent.conf
+++ b/build/trivalent.conf
@@ -54,7 +54,7 @@ if [ "$ARCH" == "x86_64" ] ; then
 
 	if [ "$ENABLE_VULKAN" == "true" ]; then
 		CHROMIUM_SYSTEM_FLAGS+=" --use-angle=vulkan --use-vulkan"
-		FEATURES+="Vulkan,DefaultANGLEVulkan,VulkanFromANGLE,VaapiIgnoreDriverChecks"
+		FEATURES+=",Vulkan,DefaultANGLEVulkan,VulkanFromANGLE,VaapiIgnoreDriverChecks"
 	fi
 fi
 

--- a/build/trivalent.conf
+++ b/build/trivalent.conf
@@ -42,10 +42,10 @@ ENABLE_VULKAN="false"
 # Other architectures are not tested for and should not be included yet
 if [ "$ARCH" == "x86_64" ] ; then
 	if [ "$USE_WAYLAND" == "false" ]; then
-		CHROMIUM_FLAGS+=" --enable-gpu-memory-buffer-video-frames"
-		CHROMIUM_FLAGS+=" --enable-zero-copy"
-		CHROMIUM_FLAGS+=" --ignore-gpu-blocklist"
-		CHROMIUM_FLAGS+=" --disable-gpu-driver-bug-workaround"
+		CHROMIUM_SYSTEM_FLAGS+=" --enable-gpu-memory-buffer-video-frames"
+		CHROMIUM_SYSTEM_FLAGS+=" --enable-zero-copy"
+		CHROMIUM_SYSTEM_FLAGS+=" --ignore-gpu-blocklist"
+		CHROMIUM_SYSTEM_FLAGS+=" --disable-gpu-driver-bug-workaround"
 
 		# Enable Vulkan
 		# (Vulkan is not supported on Wayland, it is also experimental)

--- a/build/trivalent.conf
+++ b/build/trivalent.conf
@@ -12,7 +12,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-ARCH="$(uname -m)"
 CHROMIUM_FLAGS=""
 FEATURES=""
 

--- a/build/trivalent.conf
+++ b/build/trivalent.conf
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# PLACE YOUR CONFIGS IN SEPERATE FILES
+# Changes to this file are temporary
+# Save configs in '/etc/trivalent/trivalent.conf.d' named '<name>.conf'
+# Do not use 'CHROMIUM_SYSTEM_FLAGS' in these files, only 'CHROMIUM_FLAGS'
+# Do not use the '--enable-features' flag, use 'FEATURES+='
+# Always prefix a comma to features
+
 # Copyright 2025 The Trivalent Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/build/trivalent.conf
+++ b/build/trivalent.conf
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # PLACE YOUR CONFIGS IN SEPERATE FILES
-# Changes to this file are temporary
+# Changes to this file may not persist, do not depend on changes made to this file
 # Save configs in '/etc/trivalent/trivalent.conf.d' named '<name>.conf'
 # Do not use 'CHROMIUM_SYSTEM_FLAGS' in these files, only 'CHROMIUM_FLAGS'
 # Do not use the '--enable-features' flag, use 'FEATURES+='

--- a/build/trivalent.conf
+++ b/build/trivalent.conf
@@ -12,9 +12,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-CHROMIUM_FLAGS=""
-FEATURES=""
-
 # USE_WAYLAND=[true|false|unknown]
 if command -v nvidia-smi && [ -n "$DISPLAY" ]; then
 	echo "Nvidia + X11 detected"
@@ -23,7 +20,7 @@ if command -v nvidia-smi && [ -n "$DISPLAY" ]; then
 	# We don't want to do anything specific to either Wayland or X11 in this case
 	USE_WAYLAND="unknown"
 elif [ "$USE_WAYLAND" == "true" ]; then
-    CHROMIUM_FLAGS+=" --ozone-platform=wayland"
+    CHROMIUM_SYSTEM_FLAGS+=" --ozone-platform=wayland"
 elif [ -z "$USE_WAYLAND" ]; then
 	case "$XDG_SESSION_TYPE" in
 	   wayland)
@@ -37,7 +34,7 @@ elif [ -z "$USE_WAYLAND" ]; then
 	      ;;
 	esac
 fi
-[ "$USE_WAYLAND" == "false" ] && CHROMIUM_FLAGS+=" --ozone-platform=x11"
+[ "$USE_WAYLAND" == "false" ] && CHROMIUM_SYSTEM_FLAGS+=" --ozone-platform=x11"
 
 # ENABLE_VULKAN=[true|false]
 ENABLE_VULKAN="false"
@@ -56,9 +53,9 @@ if [ "$ARCH" == "x86_64" ] ; then
 	fi
 
 	if [ "$ENABLE_VULKAN" == "true" ]; then
-		CHROMIUM_FLAGS+=" --use-angle=vulkan --use-vulkan"
+		CHROMIUM_SYSTEM_FLAGS+=" --use-angle=vulkan --use-vulkan"
 		FEATURES+="Vulkan,DefaultANGLEVulkan,VulkanFromANGLE,VaapiIgnoreDriverChecks"
 	fi
 fi
 
-[ -n "$FEATURES" ] && CHROMIUM_FLAGS+=" --enable-features=$FEATURES"
+[ -n "$FEATURES" ] && CHROMIUM_SYSTEM_FLAGS+=" --enable-features=$FEATURES"

--- a/build/trivalent.sh
+++ b/build/trivalent.sh
@@ -44,18 +44,22 @@ declare -rx CHROME_WRAPPER
 HERE="${CHROME_WRAPPER%/*}"
 declare -r HERE
 
+declare FEATURES
+deckare CHROMIUM_FLAGS
+
 # obtain extra flags that are likely user-configured
 if [[ -d "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf.d" ]]; then
   for conf_file in /etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf.d/*.conf; do
     source "$conf_file"
   done
 fi
-declare -r CHROMIUM_EXTRA_FLAGS="$CHROMIUM_EXTRA_FLAGS"
 
 # obtain chromium flags from system file
 # shellcheck source=build/trivalent.conf
+declare CHROMIUM_SYSTEM_FLAGS
 [[ -f "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf" ]] && source "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf"
-declare -r CHROMIUM_FLAGS="$CHROMIUM_FLAGS"
+
+declare -r CHROMIUM_ALL_FLAGS="$CHROMIUM_SYSTEM_FLAGS $CHROMIUM_FLAGS"
 
 # desktop integration
 declare -r xdg_app_dir="${XDG_DATA_HOME:-$HOME/.local/share/applications}"
@@ -89,8 +93,8 @@ exec 2> >(exec cat >&2)
 # If ld.so.preload is readable, it may be used to preload into the browser which we don't want
 if [[ -r "/etc/ld.so.preload" ]]; then
   # shellcheck disable=SC2086
-  exec bwrap --dev-bind / / --ro-bind-try /dev/null /etc/ld.so.preload --setenv GDK_DISABLE icon-nodes "$HERE/$CHROMIUM_NAME" $CHROMIUM_FLAGS "$@"
+  exec bwrap --dev-bind / / --ro-bind-try /dev/null /etc/ld.so.preload --setenv GDK_DISABLE icon-nodes "$HERE/$CHROMIUM_NAME" $CHROMIUM_ALL_FLAGS "$@"
 else
   # shellcheck disable=SC2086
-  GDK_DISABLE=icon-nodes exec -a "$0" "$HERE/$CHROMIUM_NAME" $CHROMIUM_FLAGS $CHROMIUM_EXTRA_FLAGS "$@"
+  GDK_DISABLE=icon-nodes exec -a "$0" "$HERE/$CHROMIUM_NAME" $CHROMIUM_ALL_FLAGS "$@"
 fi

--- a/build/trivalent.sh
+++ b/build/trivalent.sh
@@ -45,7 +45,7 @@ HERE="${CHROME_WRAPPER%/*}"
 declare -r HERE
 
 declare FEATURES
-deckare CHROMIUM_FLAGS
+declare CHROMIUM_FLAGS
 
 # obtain extra flags that are likely user-configured
 if [[ -d "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf.d" ]]; then

--- a/build/trivalent.sh
+++ b/build/trivalent.sh
@@ -22,9 +22,11 @@ declare -rx XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR"
 declare -rx XAUTHORITY="$XAUTHORITY"
 declare -rx DISPLAY="$DISPLAY"
 
+declare -r ARCH="$(uname -m)"
+
 # enable hardware CFI feature
 # https://www.gnu.org/software/libc/manual/html_node/Hardware-Capability-Tunables.html
-if [[ "$(uname -m)" == "x86_64" ]]; then
+if [[ "$ARCH" == "x86_64" ]]; then
   declare -rx GLIBC_TUNABLES="glibc.cpu.x86_ibt=on:glibc.cpu.x86_shstk=permissive"
 fi
 
@@ -42,9 +44,17 @@ declare -rx CHROME_WRAPPER
 HERE="${CHROME_WRAPPER%/*}"
 declare -r HERE
 
+# obtain extra flags that are likely user-configured
+if [[ -d "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf.d" ]]; then
+  for conf_file in /etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf.d/*.conf; do
+    source "$conf_file"
+  done
+fi
+declare -r CHROMIUM_EXTRA_FLAGS="$CHROMIUM_EXTRA_FLAGS"
+
 # obtain chromium flags from system file
 # shellcheck source=build/trivalent.conf
-[[ -f "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf" ]] && . "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf"
+[[ -f "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf" ]] && source "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf"
 declare -r CHROMIUM_FLAGS="$CHROMIUM_FLAGS"
 
 # desktop integration
@@ -82,5 +92,5 @@ if [[ -r "/etc/ld.so.preload" ]]; then
   exec bwrap --dev-bind / / --ro-bind-try /dev/null /etc/ld.so.preload --setenv GDK_DISABLE icon-nodes "$HERE/$CHROMIUM_NAME" $CHROMIUM_FLAGS "$@"
 else
   # shellcheck disable=SC2086
-  GDK_DISABLE=icon-nodes exec -a "$0" "$HERE/$CHROMIUM_NAME" $CHROMIUM_FLAGS "$@"
+  GDK_DISABLE=icon-nodes exec -a "$0" "$HERE/$CHROMIUM_NAME" $CHROMIUM_FLAGS $CHROMIUM_EXTRA_FLAGS "$@"
 fi

--- a/build/trivalent.sh
+++ b/build/trivalent.sh
@@ -59,7 +59,7 @@ fi
 declare CHROMIUM_SYSTEM_FLAGS
 [[ -f "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf" ]] && source "/etc/$CHROMIUM_NAME/$CHROMIUM_NAME.conf"
 
-declare -r CHROMIUM_ALL_FLAGS="$CHROMIUM_SYSTEM_FLAGS $CHROMIUM_FLAGS"
+declare -r CHROMIUM_ALL_FLAGS="$CHROMIUM_FLAGS $CHROMIUM_SYSTEM_FLAGS"
 
 # desktop integration
 declare -r xdg_app_dir="${XDG_DATA_HOME:-$HOME/.local/share/applications}"

--- a/build/trivalent.sh
+++ b/build/trivalent.sh
@@ -93,8 +93,8 @@ exec 2> >(exec cat >&2)
 # If ld.so.preload is readable, it may be used to preload into the browser which we don't want
 if [[ -r "/etc/ld.so.preload" ]]; then
   # shellcheck disable=SC2086
-  exec bwrap --dev-bind / / --ro-bind-try /dev/null /etc/ld.so.preload --setenv GDK_DISABLE icon-nodes "$HERE/$CHROMIUM_NAME" $CHROMIUM_ALL_FLAGS "$@"
+  exec bwrap --dev-bind / / --ro-bind-try /dev/null /etc/ld.so.preload --setenv GDK_DISABLE icon-nodes "$HERE/$CHROMIUM_NAME" "$CHROMIUM_ALL_FLAGS $@"
 else
   # shellcheck disable=SC2086
-  GDK_DISABLE=icon-nodes exec -a "$0" "$HERE/$CHROMIUM_NAME" $CHROMIUM_ALL_FLAGS "$@"
+  GDK_DISABLE=icon-nodes exec -a "$0" "$HERE/$CHROMIUM_NAME" "$CHROMIUM_ALL_FLAGS $@"
 fi

--- a/build/trivalent.spec
+++ b/build/trivalent.spec
@@ -543,6 +543,7 @@ mkdir -p %{buildroot}%{_bindir} \
 
 # install system wide chromium config
 cp -a %{SOURCE2} %{buildroot}%{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf
+mkdir %{buildroot}%{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf.d
 cp -a %{SOURCE3} %{buildroot}%{chromium_path}/%{chromium_name}.sh
 
 export BUILD_TARGET=`cat /etc/redhat-release`
@@ -637,7 +638,8 @@ fi
 %{chromium_path}/libEGL.so
 %{chromium_path}/libGLESv2.so
 # Config
-%config(noreplace) %{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf
+%config %{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf
+%config %{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf.d
 %config %{_sysconfdir}/%{chromium_name}/master_preferences
 %config %{_sysconfdir}/%{chromium_name}/policies/
 # System entries

--- a/build/trivalent.spec
+++ b/build/trivalent.spec
@@ -543,7 +543,7 @@ mkdir -p %{buildroot}%{_bindir} \
 
 # install system wide chromium config
 cp -a %{SOURCE2} %{buildroot}%{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf
-mkdir %{buildroot}%{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf.d
+mkdir -p %{buildroot}%{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf.d
 cp -a %{SOURCE3} %{buildroot}%{chromium_path}/%{chromium_name}.sh
 
 export BUILD_TARGET=`cat /etc/redhat-release`

--- a/build/trivalent.spec
+++ b/build/trivalent.spec
@@ -639,7 +639,7 @@ fi
 %{chromium_path}/libGLESv2.so
 # Config
 %config %{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf
-%config %{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf.d
+%config %{_sysconfdir}/%{chromium_name}/%{chromium_name}.conf.d/
 %config %{_sysconfdir}/%{chromium_name}/master_preferences
 %config %{_sysconfdir}/%{chromium_name}/policies/
 # System entries


### PR DESCRIPTION
This adds a directory (`trivalent.conf.d`) which can have multiple files in a similar format to `trivalent.conf`. 
With that it changes how these files and their variables are handled. To avoid declaration conflict, the system config (`trivalent.conf`) uses `CHROMIUM_SYSTEM_FLAGS`, and `CHROMIUM_FLAGS` is used by the `.d` directory conf files. `FEATURES` will add all comma-separated features to the `enable-features` flag via `CHROMIUM_SYSTEM_FLAGS`, to avoid `enable-features` overwriting itself when added multiple times.
This also makes `trivalent.conf` replaceable in the spec, since it should only be used for temporary measures.