### PR TITLE
fix: set nullglob to avoid error message about *.conf

### DIFF
--- a/build/trivalent.sh
+++ b/build/trivalent.sh
@@ -12,6 +12,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+# Make filename expansion patterns (like *.conf) expand to nothing if no files match the pattern.
+shopt -s nullglob
+
 # Sanitize & protect risky variables
 declare -rx LD_LIBRARY_PATH=""
 declare -rx LD_AUDIT=""


### PR DESCRIPTION
If `/etc/trivalent/trivalent.conf.d` is empty, then the filename expansion pattern with `*.conf` should be empty; however, for some reason, the default in bash is for such patterns to be retained with a literal `*`, and we have to set `nullglob` to fix this behavior.