### PR TITLE
fix: -ge instead of >= in shell script

### DIFF
--- a/build/trivalent.conf
+++ b/build/trivalent.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# PLACE YOUR CONFIGS IN SEPERATE FILES
+# PLACE YOUR CONFIGS IN SEPARATE FILES
 # Changes to this file may not persist, do not depend on changes made to this file
 # Save configs in '/etc/trivalent/trivalent.conf.d' named '<name>.conf'
 # Do not use 'CHROMIUM_SYSTEM_FLAGS' in these files, only 'CHROMIUM_FLAGS'
@@ -63,6 +63,6 @@ if [ "$ARCH" == "x86_64" ] ; then
 	fi
 fi
 
-[ "$BROWSER_LOG_LEVEL" >= 2 ] && CHROMIUM_SYSTEM_FLAGS+=" --enable-logging=stderr --v=1"
+[ "$BROWSER_LOG_LEVEL" -ge 2 ] && CHROMIUM_SYSTEM_FLAGS+=" --enable-logging=stderr --v=1"
 
 [ -n "$FEATURES" ] && CHROMIUM_SYSTEM_FLAGS+=" --enable-features=$FEATURES"


### PR DESCRIPTION
The POSIX `[ ]` conditional construct doesn't have a `>=` operator; `-ge` is the correct operator for the arithmetic comparison.