### PR TITLE
chore(port): port patches to 144

### DIFF
--- a/build/trivalent.spec
+++ b/build/trivalent.spec
@@ -51,7 +51,7 @@ Name:	%{chromium_name}
   -- This IS NOT the version of the browser
   -- It is only used if it is greater than the automated version detection
   -- The point is to update to an arbitrary greater release tag, like early stable or beta tags
-  local off_version_tag = "141.0.7390.127"
+  local off_version_tag = "144.0.7559.31"
   -- This was added because Google shipped an update but forgot to ship a security fix:
   --   https://github.com/uazo/cromite/issues/2427
   -- And didn't ship said update in stable.

--- a/fedora_patches/rust-clanglib.patch
+++ b/fedora_patches/rust-clanglib.patch
@@ -1,7 +1,8 @@
-diff -up chromium-141.0.7390.37/build/config/clang/BUILD.gn.rust-clang_lib chromium-141.0.7390.37/build/config/clang/BUILD.gn
---- chromium-141.0.7390.37/build/config/clang/BUILD.gn.rust-clang_lib	2025-09-23 22:21:14.000000000 +0200
-+++ chromium-141.0.7390.37/build/config/clang/BUILD.gn	2025-09-27 12:15:44.380395911 +0200
-@@ -168,7 +168,21 @@ template("clang_lib") {
+diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
+index d49f0ec758..1cc64a3a85 100644
+--- a/build/config/clang/BUILD.gn
++++ b/build/config/clang/BUILD.gn
+@@ -177,7 +177,21 @@ template("clang_lib") {
          }
        } else if (is_apple) {
          _dir = "darwin"
@@ -24,37 +25,45 @@ diff -up chromium-141.0.7390.37/build/config/clang/BUILD.gn.rust-clang_lib chrom
          if (current_cpu == "x64") {
            _dir = "x86_64-unknown-linux-gnu"
          } else if (current_cpu == "x86") {
-diff -up chromium-141.0.7390.37/build/rust/rust_bindgen_generator.gni.rust-clang_lib chromium-141.0.7390.37/build/rust/rust_bindgen_generator.gni
---- chromium-141.0.7390.37/build/rust/rust_bindgen_generator.gni.rust-clang_lib	2025-09-23 22:21:14.000000000 +0200
-+++ chromium-141.0.7390.37/build/rust/rust_bindgen_generator.gni	2025-09-27 11:41:29.777786734 +0200
-@@ -18,11 +18,11 @@ if (host_os == "win") {
- 
+diff --git a/build/rust/rust_bindgen.gni b/build/rust/rust_bindgen.gni
+index 05a660ddfc..0e9a14fb18 100644
+--- a/build/rust/rust_bindgen.gni
++++ b/build/rust/rust_bindgen.gni
+@@ -19,14 +19,14 @@ if (host_os == "win") {
+
  # On Windows, the libclang.dll is beside the bindgen.exe, otherwise it is in
  # ../lib.
 -_libclang_path = rust_bindgen_root
 +_libclang_path = clang_base_path
- if (host_os == "win") {
+ if (!use_chromium_rust_toolchain &&
+     (current_cpu == "ppc64" || current_cpu == "s390x")) {
+   _libclang_path = rust_sysroot_absolute + "/lib64"
+ } else if (host_os == "win") {
    _libclang_path += "/bin"
  } else {
 -  _libclang_path += "/lib"
 +  _libclang_path += "/lib64"
  }
- 
+
  # Template to build Rust/C bindings with bindgen.
-diff -up chromium-141.0.7390.37/build/rust/rust_bindgen.gni.rust-clang_lib chromium-141.0.7390.37/build/rust/rust_bindgen.gni
---- chromium-141.0.7390.37/build/rust/rust_bindgen.gni.rust-clang_lib	2025-09-23 22:21:14.000000000 +0200
-+++ chromium-141.0.7390.37/build/rust/rust_bindgen.gni	2025-09-27 11:41:29.777891843 +0200
-@@ -19,11 +19,11 @@ if (host_os == "win") {
- 
+diff --git a/build/rust/rust_bindgen_generator.gni b/build/rust/rust_bindgen_generator.gni
+index 0ddb769276..3bca82f6c0 100644
+--- a/build/rust/rust_bindgen_generator.gni
++++ b/build/rust/rust_bindgen_generator.gni
+@@ -26,14 +26,14 @@ if (!use_chromium_rust_toolchain &&
+
  # On Windows, the libclang.dll is beside the bindgen.exe, otherwise it is in
  # ../lib.
 -_libclang_path = rust_bindgen_root
 +_libclang_path = clang_base_path
- if (host_os == "win") {
+ if (!use_chromium_rust_toolchain &&
+     (host_cpu == "ppc64" || host_cpu == "s390x")) {
+   _libclang_path = rust_sysroot_absolute + "/lib64"
+ } else if (host_os == "win") {
    _libclang_path += "/bin"
  } else {
 -  _libclang_path += "/lib"
 +  _libclang_path += "/lib64"
  }
- 
+
  # Template to build Rust/C bindings with bindgen.

--- a/patches/add-feature-to-disable-pdf-javascript.patch
+++ b/patches/add-feature-to-disable-pdf-javascript.patch
@@ -38,16 +38,26 @@ index d41a57843a..92ca24ed0e 100644
  BASE_DECLARE_FEATURE(kAccessiblePDFForm);
  BASE_DECLARE_FEATURE(kPdfGetSaveDataInBlocks);
  BASE_DECLARE_FEATURE(kPdfIncrementalLoading);
-diff --git a/pdf/pdfium/pdfium_form_filler.cc b/pdf/pdfium/pdfium_form_filler.cc
-index f319c45d075e2..d1b311d76d1d3 100644
---- a/pdf/pdfium/pdfium_form_filler.cc
-+++ b/pdf/pdfium/pdfium_form_filler.cc
-@@ -41,6 +41,8 @@ std::string WideStringToString(FPDF_WIDESTRING wide_string) {
- 
- // static
- PDFiumFormFiller::ScriptOption PDFiumFormFiller::DefaultScriptOption() {
+diff --git a/pdf/parsed_params.cc b/pdf/parsed_params.cc
+index f5928ceb97..fd1b614065 100644
+--- a/pdf/parsed_params.cc
++++ b/pdf/parsed_params.cc
+@@ -11,6 +11,7 @@
+ #include "pdf/pdfium/pdfium_form_filler.h"
+ #include "third_party/blink/public/platform/web_string.h"
+ #include "third_party/blink/public/web/web_plugin_params.h"
++#include "pdf/pdf_features.h"
+
+ namespace chrome_pdf {
+
+@@ -27,6 +28,10 @@ ParsedParams::~ParsedParams() = default;
+ std::optional<ParsedParams> ParseWebPluginParams(
+     const blink::WebPluginParams& params) {
+   ParsedParams result;
++
 +  if (!base::FeatureList::IsEnabled(features::kPdfJavaScript))
-+    return PDFiumFormFiller::ScriptOption::kNoJavaScript;
- #if defined(PDF_ENABLE_XFA)
-   if (base::FeatureList::IsEnabled(features::kPdfXfaSupport))
-     return PDFiumFormFiller::ScriptOption::kJavaScriptAndXFA;
++    result.script_option = PDFiumFormFiller::ScriptOption::kNoJavaScript;
++
+   for (size_t i = 0; i < params.attribute_names.size(); ++i) {
+     if (params.attribute_names[i] == "src") {
+       result.src_url = params.attribute_values[i].Utf8();

--- a/patches/add-feature-to-toggle-middlemouse-copypaste.patch
+++ b/patches/add-feature-to-toggle-middlemouse-copypaste.patch
@@ -53,17 +53,17 @@ index 88ca7f0b1f..14be7e5a3a 100644
 
  // Used to enable additional a11y attributes when announcing text.
 diff --git a/ui/views/views_features.h b/ui/views/views_features.h
-index 58063f2452..3adbb7a5fb 100644
+index 5f5ea15678..6240bbae10 100644
 --- a/ui/views/views_features.h
 +++ b/ui/views/views_features.h
-@@ -17,6 +17,8 @@ VIEWS_EXPORT BASE_DECLARE_FEATURE(kEnablePlatformHighContrastInkDrop);
- VIEWS_EXPORT BASE_DECLARE_FEATURE(kEnableTouchDragCursorSync);
+@@ -17,6 +17,8 @@ VIEWS_EXPORT BASE_DECLARE_FEATURE(kEnableTouchDragCursorSync);
  VIEWS_EXPORT BASE_DECLARE_FEATURE(kKeyboardAccessibleTooltipInViews);
- 
+ VIEWS_EXPORT BASE_DECLARE_FEATURE(kApplyInitialUrlToWebContents);
+
 +VIEWS_EXPORT BASE_DECLARE_FEATURE(kMiddleClickCopyPaste);
 +
  }  // namespace views::features
- 
+
  #endif  // UI_VIEWS_VIEWS_FEATURES_H_
 diff --git a/third_party/blink/renderer/core/editing/selection_controller.cc b/third_party/blink/renderer/core/editing/selection_controller.cc
 index 8f129a1d5d..0ce49f8457 100644

--- a/patches/add-hide-profile-icon-feature.patch
+++ b/patches/add-hide-profile-icon-feature.patch
@@ -11,10 +11,10 @@ distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, e
 See the License for the specific language governing permissions and limitations under the License.
 ---
 diff --git a/chrome/browser/ui/ui_features.cc b/chrome/browser/ui/ui_features.cc
-index 703fc03b7e6cc..0623c0ed9ffab 100644
+index 6a8be4abd7..36113be58a 100644
 --- a/chrome/browser/ui/ui_features.cc
 +++ b/chrome/browser/ui/ui_features.cc
-@@ -13,6 +13,10 @@
+@@ -17,6 +17,10 @@
  
  namespace features {
  
@@ -22,22 +22,22 @@ index 703fc03b7e6cc..0623c0ed9ffab 100644
 +BASE_FEATURE(kHideProfileIcon, "HideProfileIcon",
 +             base::FEATURE_DISABLED_BY_DEFAULT);
 +
- // Enables the tab dragging fallback when full window dragging is not supported
- // by the platform (e.g. Wayland). See https://crbug.com/896640
- BASE_FEATURE(kAllowWindowDragUsingSystemDragDrop,
+ // Enables the use of WGC for the Eye Dropper screen capture.
+ BASE_FEATURE(kAllowEyeDropperWGCScreenCapture,
+ #if BUILDFLAG(IS_WIN)
 diff --git a/chrome/browser/ui/ui_features.h b/chrome/browser/ui/ui_features.h
-index 504a3419f1bb0..341667da5e703 100644
+index d4456c7bf1..adb2bf2ef7 100644
 --- a/chrome/browser/ui/ui_features.h
 +++ b/chrome/browser/ui/ui_features.h
-@@ -21,6 +21,8 @@ namespace features {
+@@ -20,6 +20,8 @@ namespace features {
  // All features in alphabetical order. The features should be documented
  // alongside the definition of their values in the .cc file.
- 
+
 +BASE_DECLARE_FEATURE(kHideProfileIcon);
 +
- // TODO(crbug.com/40598679): Remove this when the tab dragging
- // interactive_ui_tests pass on Wayland.
- BASE_DECLARE_FEATURE(kAllowWindowDragUsingSystemDragDrop);
+ BASE_DECLARE_FEATURE(kAllowEyeDropperWGCScreenCapture);
+ 
+ BASE_DECLARE_FEATURE(kCreateNewTabGroupAppMenuTopLevel);
 diff --git a/chrome/browser/ui/views/toolbar/toolbar_view.cc b/chrome/browser/ui/views/toolbar/toolbar_view.cc
 index d1519e7f3782a..548be223ca340 100644
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc

--- a/patches/adjust-jit-controls.patch
+++ b/patches/adjust-jit-controls.patch
@@ -78,19 +78,19 @@ index 512feca6fa..821a9254a0 100644
 
    if (DisallowV8FeatureFlagOverrides()) {
 diff --git a/content/public/common/content_features.cc b/content/public/common/content_features.cc
-index 57f1ff40ca..d3dbe66e23 100644
+index b0162fdbdc..b2d291d8ea 100644
 --- a/content/public/common/content_features.cc
 +++ b/content/public/common/content_features.cc
-@@ -17,6 +17,8 @@
+@@ -19,6 +19,8 @@ namespace features {
 
- namespace features {
+ // All features in alphabetical order.
 
 +BASE_FEATURE(kEnableDrumbrake, base::FEATURE_ENABLED_BY_DEFAULT);
 +
- // All features in alphabetical order.
-
- // Kill switch to guard additional security checks performed by the browser
-@@ -1019,7 +1021,7 @@ BASE_FEATURE(kDisableProcessReuse, base::FEATURE_DISABLED_BY_DEFAULT);
+ // Marks navigations as aborted when the NavigationHandle is destroyed mid
+ // navigation, likely due to a tab closure. This is a kill switch.
+ BASE_FEATURE(kAbortNavigationsFromTabClosures,
+@@ -1013,7 +1015,7 @@ BASE_FEATURE(kDisableProcessReuse, base::FEATURE_DISABLED_BY_DEFAULT);
  // Controls whether SpareRenderProcessHostManager tries to always have a warm
  // spare renderer process around for the most recently requested BrowserContext.
  // This feature is only consulted in site-per-process mode.
@@ -100,18 +100,18 @@ index 57f1ff40ca..d3dbe66e23 100644
  // Controls whether site isolation should use origins instead of scheme and
  // eTLD+1.
 diff --git a/content/public/common/content_features.h b/content/public/common/content_features.h
-index 34478026bd..be37022a43 100644
+index ae18db8a3d..5bbf28711b 100644
 --- a/content/public/common/content_features.h
 +++ b/content/public/common/content_features.h
-@@ -23,6 +23,8 @@ namespace features {
+@@ -24,6 +24,8 @@ namespace features {
  // BEFORE MODIFYING THIS FILE: If your feature is only used inside content/, add
  // your feature in `content/common/features.h` instead.
- 
+
 +CONTENT_EXPORT BASE_DECLARE_FEATURE(kEnableDrumbrake);
 +
  // All features in alphabetical order. The features should be documented
  // alongside the definition of their values in the .cc file.
- CONTENT_EXPORT BASE_DECLARE_FEATURE(kAdditionalOpaqueOriginEnforcements);
+ CONTENT_EXPORT BASE_DECLARE_FEATURE(kAbortNavigationsFromTabClosures);
 diff --git a/v8/BUILD.gn b/v8/BUILD.gn
 index 8dda88f8..e08a4de7 100644
 --- a/v8/BUILD.gn

--- a/patches/adjust-jit-controls.patch
+++ b/patches/adjust-jit-controls.patch
@@ -11,13 +11,13 @@ distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, e
 See the License for the specific language governing permissions and limitations under the License.
 ---
 diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
-index 87a95ef582..a2ba4a1678 100644
+index 900df063b8..287de90eb1 100644
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -7731,10 +7731,10 @@ bool ChromeContentBrowserClient::IsJitDisabledForSite(
+@@ -7761,10 +7761,10 @@ bool ChromeContentBrowserClient::IsJitDisabledForSite(
                                           nullptr) == CONTENT_SETTING_BLOCK;
    }
-
+ 
 -  // Only disable JIT for web schemes.
 -  if (!site_url.SchemeIsHTTPOrHTTPS()) {
 -    return false;
@@ -26,23 +26,29 @@ index 87a95ef582..a2ba4a1678 100644
 +  if (!site_url.SchemeIsHTTPOrHTTPS() && !site_url.SchemeIsFile()
 +      && !site_url.SchemeIs("chrome-extension"))
 +    return true;
-
+ 
    return (map && map->GetContentSetting(site_url, site_url,
                                          ContentSettingsType::JAVASCRIPT_JIT) ==
-@@ -7744,13 +7744,6 @@ bool ChromeContentBrowserClient::IsJitDisabledForSite(
- bool ChromeContentBrowserClient::AreV8OptimizationsDisabledForSite(
-     content::BrowserContext* browser_context,
+@@ -7776,18 +7776,10 @@ bool ChromeContentBrowserClient::AreV8OptimizationsEnabledForSite(
+     const std::optional<base::SafeRef<content::ProcessSelectionUserData>>&
+         process_selection_user_data,
      const GURL& site_url) {
 -  // Only disable optimizations for schemes that might actually load web
--  // content.
+-  // content. This check enables v8-optimization for schemes such as chrome://
+-  // and chrome-untrusted://.
 -  auto* policy = ChildProcessSecurityPolicy::GetInstance();
 -  if (!site_url.is_empty() && !policy->IsWebSafeScheme(site_url.GetScheme())) {
--    return false;
+-    return true;
 -  }
 -
    Profile* profile = Profile::FromBrowserContext(browser_context);
    auto* map = HostContentSettingsMapFactory::GetForProfile(profile);
-   // Special case to determine if any policy is set.
+   if (!map) {
+-    return true;
++    return false;
+   }
+ 
+   if (site_url.is_empty()) {
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
 index 512feca6fa..821a9254a0 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc

--- a/patches/adjust-user-preferences.patch
+++ b/patches/adjust-user-preferences.patch
@@ -432,18 +432,18 @@ index 6b9bd1adee..6e0bea5eee 100644
 +    </div>
    </settings-subpage>
 diff --git a/chrome/browser/resources/settings/privacy_page/security/security_page.ts b/chrome/browser/resources/settings/privacy_page/security/security_page.ts
-index 15c880bbaa..21d79a36a3 100644
+index 92eb5ebaef..aa8fe10e53 100644
 --- a/chrome/browser/resources/settings/privacy_page/security/security_page.ts
 +++ b/chrome/browser/resources/settings/privacy_page/security/security_page.ts
-@@ -31,6 +31,7 @@ import {PolymerElement} from 'chrome://resources/polymer/v3_0/polymer/polymer_bu
+@@ -33,6 +33,7 @@ import {PolymerElement} from 'chrome://resources/polymer/v3_0/polymer/polymer_bu
  import type {SettingsCollapseRadioButtonElement} from '../../controls/collapse_radio_button.js';
  import type {SettingsRadioGroupElement} from '../../controls/settings_radio_group.js';
  import type {SettingsToggleButtonElement} from '../../controls/settings_toggle_button.js';
 +import type {DropdownMenuOptionList} from '../../controls/settings_dropdown_menu.js';
- import {HatsBrowserProxyImpl, SecurityPageInteraction} from '../../hats_browser_proxy.js';
  import {loadTimeData} from '../../i18n_setup.js';
  import type {MetricsBrowserProxy} from '../../metrics_browser_proxy.js';
-@@ -123,6 +124,19 @@ export class SettingsSecurityPageElement extends
+ import {MetricsBrowserProxyImpl, PrivacyElementInteractions, SafeBrowsingInteractions} from '../../metrics_browser_proxy.js';
+@@ -112,6 +113,19 @@ export class SettingsSecurityPageElement extends
        },
        // </if>
 
@@ -463,15 +463,15 @@ index 15c880bbaa..21d79a36a3 100644
        /**
         * Valid safe browsing states.
         */
-@@ -214,6 +228,7 @@ export class SettingsSecurityPageElement extends
-       },
+@@ -176,6 +190,7 @@ export class SettingsSecurityPageElement extends
+       showDisableSafebrowsingDialog_: Boolean,
      };
    }
 +  declare private webrtcHandlingPolicyOptions_: DropdownMenuOptionList;
    declare private showSecureDnsSetting_: boolean;
 
    // <if expr="is_chromeos">
-@@ -265,10 +280,6 @@ export class SettingsSecurityPageElement extends
+@@ -219,10 +234,6 @@ export class SettingsSecurityPageElement extends
        }
      });
 
@@ -479,9 +479,9 @@ index 15c880bbaa..21d79a36a3 100644
 -        'kEnhancedProtectionSettingElementId',
 -        this.$.safeBrowsingEnhanced.getBubbleAnchor(), {anchorPaddingTop: 10});
 -
-     // Initialize the last focus time on page load.
-     this.lastFocusTime_ = HatsBrowserProxyImpl.getInstance().now();
- 
+     this.addWebUiListener(
+         'contentSettingCategoryChanged', (category: ContentSettingsTypes) => {
+           if (category === ContentSettingsTypes.JAVASCRIPT_OPTIMIZER) {
 diff --git a/chrome/browser/resources/settings/route.ts b/chrome/browser/resources/settings/route.ts
 index 1fd9c83cb7..931b3b5aee 100644
 --- a/chrome/browser/resources/settings/route.ts

--- a/patches/adjust-user-preferences.patch
+++ b/patches/adjust-user-preferences.patch
@@ -54,10 +54,10 @@ index 87b28c196eb30..5d3a56f226044 100644
    <div id="bulletpoints-wrapper">
      <div class="bulletpoints first">$i18nRaw{incognitoTabFeatures}</div>
      <div class="bulletpoints">$i18nRaw{incognitoTabWarning}</div>
-diff --git a/chrome/browser/resources/settings/a11y_page/live_translate_section.html b/chrome/browser/resources/settings/a11y_page/live_translate_section.html
-index 3fce5bc069911..c8ce8d033c500 100644
---- a/chrome/browser/resources/settings/a11y_page/live_translate_section.html
-+++ b/chrome/browser/resources/settings/a11y_page/live_translate_section.html
+diff --git a/chrome/browser/resources/settings/a11y_page/live_translate.html b/chrome/browser/resources/settings/a11y_page/live_translate.html
+index 3fce5bc069..c8ce8d033c 100644
+--- a/chrome/browser/resources/settings/a11y_page/live_translate.html
++++ b/chrome/browser/resources/settings/a11y_page/live_translate.html
 @@ -25,28 +25,3 @@
      width: 100%;
    }

--- a/patches/disable-global-shortcuts-portal.patch
+++ b/patches/disable-global-shortcuts-portal.patch
@@ -15,10 +15,11 @@ index a82a333a97..cfdaa62866 100644
 --- a/ui/base/accelerators/global_accelerator_listener/global_accelerator_listener_ozone.cc
 +++ b/ui/base/accelerators/global_accelerator_listener/global_accelerator_listener_ozone.cc
 @@ -25,7 +25,7 @@ using content::BrowserThread;
-
+ 
  namespace {
  #if BUILDFLAG(IS_LINUX) && BUILDFLAG(USE_DBUS)
 -BASE_FEATURE(kGlobalShortcutsPortal, base::FEATURE_ENABLED_BY_DEFAULT);
 +BASE_FEATURE(kGlobalShortcutsPortal, base::FEATURE_DISABLED_BY_DEFAULT);
-
+ 
  constexpr char kSessionSuffix[] = "_global_shortcuts";
+ 

--- a/patches/disable-global-shortcuts-portal.patch
+++ b/patches/disable-global-shortcuts-portal.patch
@@ -11,15 +11,14 @@ distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, e
 See the License for the specific language governing permissions and limitations under the License.
 ---
 diff --git a/ui/base/accelerators/global_accelerator_listener/global_accelerator_listener_ozone.cc b/ui/base/accelerators/global_accelerator_listener/global_accelerator_listener_ozone.cc
-index ce768e551d..624255d55c 100644
+index a82a333a97..cfdaa62866 100644
 --- a/ui/base/accelerators/global_accelerator_listener/global_accelerator_listener_ozone.cc
 +++ b/ui/base/accelerators/global_accelerator_listener/global_accelerator_listener_ozone.cc
-@@ -24,7 +24,7 @@ using content::BrowserThread;
+@@ -25,7 +25,7 @@ using content::BrowserThread;
 
  namespace {
  #if BUILDFLAG(IS_LINUX) && BUILDFLAG(USE_DBUS)
 -BASE_FEATURE(kGlobalShortcutsPortal, base::FEATURE_ENABLED_BY_DEFAULT);
 +BASE_FEATURE(kGlobalShortcutsPortal, base::FEATURE_DISABLED_BY_DEFAULT);
- constexpr char kChannelEnvVar[] = "CHROME_VERSION_EXTRA";
 
- #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
+ constexpr char kSessionSuffix[] = "_global_shortcuts";

--- a/patches/disable-metrics-reporting.patch
+++ b/patches/disable-metrics-reporting.patch
@@ -11,15 +11,15 @@ distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, e
 See the License for the specific language governing permissions and limitations under the License.
 ---
 diff --git a/chrome/browser/browser_process_impl.cc b/chrome/browser/browser_process_impl.cc
-index d2e348767ab87..b7c7b27bb6ab8 100644
+index 3c9be757d6..67b9dc47b9 100644
 --- a/chrome/browser/browser_process_impl.cc
 +++ b/chrome/browser/browser_process_impl.cc
-@@ -1130,7 +1130,7 @@ void BrowserProcessImpl::RegisterPrefs(PrefRegistrySimple* registry) {
+@@ -1188,7 +1188,7 @@ void BrowserProcessImpl::RegisterPrefs(PrefRegistrySimple* registry) {
  #endif  // BUILDFLAG(IS_CHROMEOS)
- 
+
    registry->RegisterBooleanPref(metrics::prefs::kMetricsReportingEnabled,
 -                                GoogleUpdateSettings::GetCollectStatsConsent());
 +                                false);
    registry->RegisterBooleanPref(prefs::kDevToolsRemoteDebuggingAllowed, true);
+   registry->RegisterBooleanPref(prefs::kDevToolsRemoteDebuggingEnabled, false);
  
- #if BUILDFLAG(IS_LINUX)

--- a/patches/dns-providers.patch
+++ b/patches/dns-providers.patch
@@ -11,19 +11,10 @@ distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, e
 See the License for the specific language governing permissions and limitations under the License.
 ---
 diff --git a/net/dns/public/doh_provider_entry.cc b/net/dns/public/doh_provider_entry.cc
-index 910a0c91aa1fa..bfe959f1475f2 100644
+index 0bf0282647..9025bae876 100644
 --- a/net/dns/public/doh_provider_entry.cc
 +++ b/net/dns/public/doh_provider_entry.cc
-@@ -77,7 +77,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
-         /*ui_name=*/"alekberg.net (NL)",
-         /*privacy_policy=*/"https://alekberg.net/privacy",
-         /*display_globally=*/false,
--        /*display_countries=*/{"NL"}, LoggingLevel::kNormal},
-+        /*display_countries=*/{}, LoggingLevel::kNormal},
-        {"CleanBrowsingAdult",
-         MAKE_BASE_FEATURE_WITH_STATIC_STORAGE(DohProviderCleanBrowsingAdult,
-                                               base::FEATURE_ENABLED_BY_DEFAULT),
-@@ -99,7 +99,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+@@ -90,7 +90,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
          "https://doh.cleanbrowsing.org/doh/family-filter{?dns}",
          /*ui_name=*/"CleanBrowsing (Family Filter)",
          /*privacy_policy=*/"https://cleanbrowsing.org/privacy",
@@ -32,15 +23,13 @@ index 910a0c91aa1fa..bfe959f1475f2 100644
          /*display_countries=*/{},
          LoggingLevel::kNormal},
         {"CleanBrowsingSecure",
-@@ -117,15 +117,107 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
-         MAKE_BASE_FEATURE_WITH_STATIC_STORAGE(DohProviderCloudflare,
+@@ -109,14 +109,106 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
                                                base::FEATURE_ENABLED_BY_DEFAULT),
          {"1.1.1.1", "1.0.0.1", "2606:4700:4700::1111", "2606:4700:4700::1001"},
--        /*dns_over_tls_hostnames=*/
+         /*dns_over_tls_hostnames=*/
 -        {"one.one.one.one", "1dot1dot1dot1.cloudflare-dns.com"},
 -        "https://chrome.cloudflare-dns.com/dns-query",
-+        /*dns_over_tls_hostnames=*/{"one.one.one.one", "cloudflare-dns.com",
-+        "1dot1dot1dot1.cloudflare-dns.com"},
++        {"one.one.one.one", "1dot1dot1dot1.cloudflare-dns.com", "cloudflare-dns.com"},
 +        "https://cloudflare-dns.com/dns-query",
          /*ui_name=*/"Cloudflare (1.1.1.1)",
          "https://developers.cloudflare.com/1.1.1.1/privacy/"
@@ -143,7 +132,7 @@ index 910a0c91aa1fa..bfe959f1475f2 100644
         {"Comcast",
          MAKE_BASE_FEATURE_WITH_STATIC_STORAGE(DohProviderComcast,
                                                base::FEATURE_ENABLED_BY_DEFAULT),
-@@ -181,7 +273,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+@@ -191,7 +283,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
          /*ui_name=*/"Google (Public DNS)",
          "https://developers.google.com/speed/public-dns/"
          /*privacy_policy=*/"privacy",
@@ -152,7 +141,16 @@ index 910a0c91aa1fa..bfe959f1475f2 100644
          /*display_countries=*/{},
          LoggingLevel::kExtra},
         {"GoogleDns64",
-@@ -225,7 +317,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+@@ -212,7 +304,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+         /*dns_over_tls_hostnames=*/{}, "https://public.dns.iij.jp/dns-query",
+         /*ui_name=*/"IIJ (Public DNS)",
+         /*privacy_policy=*/"https://policy.public.dns.iij.jp/",
+-        /*display_globally=*/false, /*display_countries=*/{"JP"},
++        /*display_globally=*/false, /*display_countries=*/{},
+         LoggingLevel::kNormal},
+        {"Levonet",
+         MAKE_BASE_FEATURE_WITH_STATIC_STORAGE(DohProviderLevonet,
+@@ -235,7 +327,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
          /*dns_over_tls_hostnames=*/{}, "https://chromium.dns.nextdns.io",
          /*ui_name=*/"NextDNS",
          /*privacy_policy=*/"https://nextdns.io/privacy",
@@ -161,7 +159,7 @@ index 910a0c91aa1fa..bfe959f1475f2 100644
          LoggingLevel::kNormal},
         {"OpenDNS",
          MAKE_BASE_FEATURE_WITH_STATIC_STORAGE(DohProviderOpenDNS,
-@@ -237,7 +329,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+@@ -247,7 +339,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
          /*ui_name=*/"OpenDNS",
          "https://www.cisco.com/c/en/us/about/legal/"
          /*privacy_policy=*/"privacy-full.html",
@@ -170,7 +168,7 @@ index 910a0c91aa1fa..bfe959f1475f2 100644
          /*display_countries=*/{},
          LoggingLevel::kNormal},
         {"OpenDNSFamily",
-@@ -282,7 +374,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+@@ -292,7 +384,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
          "https://dns.quad9.net/dns-query",
          /*ui_name=*/"Quad9 (9.9.9.9)",
          /*privacy_policy=*/"https://www.quad9.net/home/privacy/",

--- a/patches/dns-providers.patch
+++ b/patches/dns-providers.patch
@@ -11,7 +11,7 @@ distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, e
 See the License for the specific language governing permissions and limitations under the License.
 ---
 diff --git a/net/dns/public/doh_provider_entry.cc b/net/dns/public/doh_provider_entry.cc
-index 0bf0282647..9025bae876 100644
+index 0bf0282647..c88056aab5 100644
 --- a/net/dns/public/doh_provider_entry.cc
 +++ b/net/dns/public/doh_provider_entry.cc
 @@ -90,7 +90,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
@@ -132,7 +132,19 @@ index 0bf0282647..9025bae876 100644
         {"Comcast",
          MAKE_BASE_FEATURE_WITH_STATIC_STORAGE(DohProviderComcast,
                                                base::FEATURE_ENABLED_BY_DEFAULT),
-@@ -191,7 +283,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+@@ -162,10 +254,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+         "https://app-eu1.hubspotdocuments.com/documents/142290803/view/"
+         "1331719984?accessId=b505d9",
+         /*display_globally=*/false,
+-        /*display_countries=*/{"AT", "BE", "BG", "HR", "CY", "CZ", "DK",
+-                               "EE", "FI", "FR", "DE", "GR", "HU", "IE",
+-                               "IT", "LV", "LT", "LU", "MT", "NL", "PL",
+-                               "PT", "RO", "SK", "SI", "ES", "SE"},
++        /*display_countries=*/{},
+         LoggingLevel::kNormal,
+         /*dns_over_https_server_ip_strs=*/
+         {"86.54.11.1", "86.54.11.201", "2a13:1001::86:54:11:1",
+@@ -191,7 +280,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
          /*ui_name=*/"Google (Public DNS)",
          "https://developers.google.com/speed/public-dns/"
          /*privacy_policy=*/"privacy",
@@ -141,7 +153,7 @@ index 0bf0282647..9025bae876 100644
          /*display_countries=*/{},
          LoggingLevel::kExtra},
         {"GoogleDns64",
-@@ -212,7 +304,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+@@ -212,7 +301,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
          /*dns_over_tls_hostnames=*/{}, "https://public.dns.iij.jp/dns-query",
          /*ui_name=*/"IIJ (Public DNS)",
          /*privacy_policy=*/"https://policy.public.dns.iij.jp/",
@@ -150,7 +162,7 @@ index 0bf0282647..9025bae876 100644
          LoggingLevel::kNormal},
         {"Levonet",
          MAKE_BASE_FEATURE_WITH_STATIC_STORAGE(DohProviderLevonet,
-@@ -235,7 +327,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+@@ -235,7 +324,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
          /*dns_over_tls_hostnames=*/{}, "https://chromium.dns.nextdns.io",
          /*ui_name=*/"NextDNS",
          /*privacy_policy=*/"https://nextdns.io/privacy",
@@ -159,7 +171,7 @@ index 0bf0282647..9025bae876 100644
          LoggingLevel::kNormal},
         {"OpenDNS",
          MAKE_BASE_FEATURE_WITH_STATIC_STORAGE(DohProviderOpenDNS,
-@@ -247,7 +339,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+@@ -247,7 +336,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
          /*ui_name=*/"OpenDNS",
          "https://www.cisco.com/c/en/us/about/legal/"
          /*privacy_policy=*/"privacy-full.html",
@@ -168,7 +180,7 @@ index 0bf0282647..9025bae876 100644
          /*display_countries=*/{},
          LoggingLevel::kNormal},
         {"OpenDNSFamily",
-@@ -292,7 +384,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
+@@ -292,7 +381,7 @@ const DohProviderEntry::List& DohProviderEntry::GetList() {
          "https://dns.quad9.net/dns-query",
          /*ui_name=*/"Quad9 (9.9.9.9)",
          /*privacy_policy=*/"https://www.quad9.net/home/privacy/",

--- a/patches/linux-gpu-sandbox.patch
+++ b/patches/linux-gpu-sandbox.patch
@@ -274,24 +274,24 @@ index 28d9ac5174..f621437301 100644
      return prefs.enable_low_latency_dxva;
    }
 diff --git a/gpu/ipc/service/gpu_init.cc b/gpu/ipc/service/gpu_init.cc
-index 6ea960c6f8..a22bc31453 100644
+index f7044194b5..0336958235 100644
 --- a/gpu/ipc/service/gpu_init.cc
 +++ b/gpu/ipc/service/gpu_init.cc
 @@ -54,6 +54,10 @@
  #include <GLES2/gl2.h>
  #endif
- 
+
 +#if BUILDFLAG(IS_LINUX)
 +#include "third_party/angle/src/gpu_info_util/SystemInfo.h"
 +#endif
 +
  #if BUILDFLAG(IS_OZONE)
+ #if BUILDFLAG(ENABLE_VULKAN)
  #include "gpu/command_buffer/service/drm_modifiers_filter_vulkan.h"
- #include "ui/ozone/public/drm_modifiers_filter.h"
-@@ -352,6 +356,14 @@ GpuInit::~GpuInit() {
+@@ -354,6 +358,14 @@ GpuInit::~GpuInit() {
    StopForceDiscreteGPU();
  }
- 
+
 +// TODO: Add the following
 +//angle::IsNVIDIA(vendor_id)
 +//angle::IsVirtIO(vendor_id)
@@ -303,10 +303,10 @@ index 6ea960c6f8..a22bc31453 100644
  bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
                                          const GpuPreferences& gpu_preferences) {
    TRACE_EVENT("gpu,startup", "gpu::GpuInit::InitializeAndStartSandbox");
-@@ -418,8 +430,21 @@ bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
+@@ -420,8 +432,21 @@ bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
    enable_watchdog = false;
  #endif
- 
+
 +  bool gpu_sandbox_linux = gpu_preferences_.gpu_sandbox_linux;
  #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS)
 -  bool gpu_sandbox_start_early = gpu_preferences_.gpu_sandbox_start_early;
@@ -326,7 +326,7 @@ index 6ea960c6f8..a22bc31453 100644
  #else   // !(BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS))
    // For some reasons MacOSX's VideoToolbox might crash when called after
    // initializing GL, see crbug.com/1047643 and crbug.com/871280. On other
-@@ -460,7 +485,7 @@ bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
+@@ -462,7 +487,7 @@ bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
    // On Chrome OS ARM Mali, GPU driver userspace creates threads when
    // initializing a GL context, so start the sandbox early.
    // TODO(zmo): Need to collect OS version before this.

--- a/patches/trivalent-code-references.patch
+++ b/patches/trivalent-code-references.patch
@@ -46,7 +46,7 @@ index a08e42a464..9453bbeefe 100644
 -constexpr char kBrowserDisplayName[] = "chromium-browser";
 -#define PRODUCT_STRING "Chromium"
 +constexpr char kBrowserDisplayName[] = "trivalent";
-+#define PRODUCT_STRING "TRIVALENT"
++#define PRODUCT_STRING "Trivalent"
  #endif
  
  #if defined(DLOPEN_PULSEAUDIO)

--- a/patches/trivalent-code-references.patch
+++ b/patches/trivalent-code-references.patch
@@ -49,28 +49,37 @@ index a3523a9bbb1d7..460fdbe273da2 100644
  #endif
  
 diff --git a/base/files/file_util_posix.cc b/base/files/file_util_posix.cc
-index 84e81affcb..13d5c0f601 100644
+index 9661e09573..3bba1abafa 100644
 --- a/base/files/file_util_posix.cc
 +++ b/base/files/file_util_posix.cc
-@@ -870,7 +870,7 @@ FilePath FormatTemporaryFileName(FilePath::StringViewType identifier) {
+@@ -879,7 +879,7 @@ FilePath FormatTemporaryFileName(FilePath::StringViewType identifier,
  #elif BUILDFLAG(GOOGLE_CHROME_BRANDING)
    std::string_view prefix = "com.google.Chrome";
  #else
 -  std::string_view prefix = "org.chromium.Chromium";
 +  std::string_view prefix = "dev.secureblue.Trivalent";
  #endif
-   return FilePath(StrCat({".", prefix, ".", identifier}));
+   return FilePath(StrCat({hidden ? "." : "", prefix, ".", identifier}));
  }
-diff --git a/components/dbus/xdg/systemd.cc b/components/dbus/xdg/systemd.cc
-index 88a595c3eb..ac7f3cb675 100644
---- a/components/dbus/xdg/systemd.cc
-+++ b/components/dbus/xdg/systemd.cc
-@@ -55,7 +55,7 @@ constexpr char kChannelEnvVar[] = "CHROME_VERSION_EXTRA";
+diff --git a/base/version_info/nix/version_extra_utils.cc b/base/version_info/nix/version_extra_utils.cc
+index e48fbf2976..1166cf83be 100644
+--- a/base/version_info/nix/version_extra_utils.cc
++++ b/base/version_info/nix/version_extra_utils.cc
+@@ -39,7 +39,7 @@ std::string GetAppName(base::Environment& env) {
  #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
- constexpr char kAppNamePrefix[] = "com.google.Chrome";
+   static constexpr std::string_view kAppName = "com.google.Chrome";
  #else
--constexpr char kAppNamePrefix[] = "org.chromium.Chromium";
-+constexpr char kAppNamePrefix[] = "dev.secureblue.Trivalent";
+-  static constexpr std::string_view kAppName = "org.chromium.Chromium";
++  static constexpr std::string_view kAppName = "dev.secureblue.Trivalent";
  #endif
- 
- const char* GetAppNameSuffix(const std::string& channel) {
+
+   std::string_view suffix;
+@@ -64,7 +64,7 @@ std::string GetSessionNamePrefix(base::Environment& env) {
+ #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
+   static constexpr std::string_view kSessionNamePrefix = "chrome";
+ #else
+-  static constexpr std::string_view kSessionNamePrefix = "chromium";
++  static constexpr std::string_view kSessionNamePrefix = "trivalent";
+ #endif
+
+   std::string_view suffix;

--- a/patches/trivalent-code-references.patch
+++ b/patches/trivalent-code-references.patch
@@ -36,18 +36,20 @@ index eb94a11e5c932..25c4e240eb919 100644
    // Google Chrome packaged as a snap is a special case: the application name
    // is always "google-chrome", regardless of the channel (channels are built
 diff --git a/media/audio/pulse/pulse_util.cc b/media/audio/pulse/pulse_util.cc
-index a3523a9bbb1d7..460fdbe273da2 100644
+index a08e42a464..9453bbeefe 100644
 --- a/media/audio/pulse/pulse_util.cc
 +++ b/media/audio/pulse/pulse_util.cc
-@@ -44,7 +44,7 @@ namespace {
+@@ -39,8 +39,8 @@ namespace {
  constexpr char kBrowserDisplayName[] = "google-chrome";
  #define PRODUCT_STRING "Google Chrome"
  #else
 -constexpr char kBrowserDisplayName[] = "chromium-browser";
+-#define PRODUCT_STRING "Chromium"
 +constexpr char kBrowserDisplayName[] = "trivalent";
- #define PRODUCT_STRING "Chromium"
++#define PRODUCT_STRING "TRIVALENT"
  #endif
  
+ #if defined(DLOPEN_PULSEAUDIO)
 diff --git a/base/files/file_util_posix.cc b/base/files/file_util_posix.cc
 index 9661e09573..3bba1abafa 100644
 --- a/base/files/file_util_posix.cc


### PR DESCRIPTION
Some patches will need some testing due to changes in 144:
- `add-feature-to-disable-pdf-javascript.patch`, changed handling logic for JavaScript in PDF documents
- `add-feature-to-toggle-middlemouse-copypaste.patch`, logic was added to handle system configuration for primary paste (middle click paste), the patch could be updated to integrate with that