### PR TITLE
feat: make subpackage for Trivalent SELinux policy

### DIFF
--- a/build/trivalent.fc
+++ b/build/trivalent.fc
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/usr/lib/trivalent/trivalent				--	gen_context(system_u:object_r:trivalent_exec_t,s0)
+
+# TODO: move crashpad handler to its own dom
+/usr/lib/trivalent/chrome_crashpad_handler			--	gen_context(system_u:object_r:trivalent_exec_t,s0)
+/usr/lib/trivalent/trivalent.sh				--	gen_context(system_u:object_r:trivalent_script_exec_t,s0)
+/usr/lib/trivalent/install_filter.sh				--	gen_context(system_u:object_r:trivalent_script_exec_t,s0)
+HOME_DIR/\.cache/trivalent(/.*)?		gen_context(system_u:object_r:trivalent_home_t,s0)
+HOME_DIR/\.config/trivalent(/.*)?	gen_context(system_u:object_r:trivalent_home_t,s0)

--- a/build/trivalent.if
+++ b/build/trivalent.if
@@ -1,0 +1,105 @@
+## <summary>trivalent browser</summary>
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+########################################
+## <summary>
+##	Allow role to run Trivalent from the given domain.
+## </summary>
+## <param name="domain_prefix">
+##	<summary>
+##	The prefix of the domain (e.g., user is the prefix for user_t).
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role (or role attribute) allowed access.
+##	</summary>
+## </param>
+## <param name="domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+#
+template(`trivalent_role_template',`
+	gen_require(`
+		attribute_role trivalent_roles;
+		attribute trivalent_domain;
+		attribute trivalent_script_domain;
+	')
+
+	##############################
+	#
+	# Declarations
+	#
+
+	roleattribute $2 trivalent_roles;
+
+	type $1_trivalent_t, trivalent_domain;
+	application_domain($1_trivalent_t, trivalent_exec_t)
+	ubac_constrained($1_trivalent_t)
+
+	type $1_trivalent_script_t, trivalent_script_domain;
+	application_domain($1_trivalent_script_t, trivalent_script_exec_t)
+	ubac_constrained($1_trivalent_script_t)
+
+	role $2 types { $1_trivalent_t $1_trivalent_script_t };
+
+	##############################
+	#
+	# Local policy
+	#
+
+	domtrans_pattern($3, trivalent_script_exec_t, $1_trivalent_script_t)
+	domtrans_pattern($1_trivalent_script_t, trivalent_exec_t, $1_trivalent_t)
+	allow $1_trivalent_script_t $1_trivalent_t:process2 { nosuid_transition nnp_transition };
+	trivalent_filetrans_home_content($3)
+
+	# screenshare access
+	allow $1_trivalent_t $3:unix_stream_socket { connectto rw_socket_perms };
+
+	kernel_read_system_state($1_trivalent_t)
+	pulseaudio_tmpfs_content($1_trivalent_t)
+
+	optional_policy(`
+		gen_require(`
+			type user_tmpfs_t;
+		')
+		xserver_user_x_domain_template($1_trivalent, $1_trivalent_t, user_tmpfs_t)
+	')
+
+	# Trivalent-Flatpak integration
+	# uncomment this once new flatpak policy is in use
+	# optional_policy(`
+	# 	flatpak_role_template($1_trivalent, $2, $1_trivalent_t, $1_t)
+	# 	allow $1_trivalent_t $1_trivalent_flatpak_t:process2 { nnp_transition nosuid_transition };
+	# 	write_fifo_files_pattern($1_trivalent_flatpak_t, $1_trivalent_script_t, $1_trivalent_script_t)
+	# 	# write_fifo_files_pattern($3, $1_trivalent_script_t, $1_trivalent_script_t)
+	# ')
+')
+
+
+########################################
+## <summary>
+##	Create trivalent directory in the user home directory
+##	with an correct label.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`trivalent_filetrans_home_content',`
+	gen_require(`
+		type trivalent_home_t;
+	')
+
+	optional_policy(`
+		gnome_config_filetrans($1, trivalent_home_t, dir, "trivalent")
+		gnome_cache_filetrans($1, trivalent_home_t, dir, "trivalent")
+	')
+')

--- a/build/trivalent.spec
+++ b/build/trivalent.spec
@@ -18,6 +18,10 @@
 %global chromium_name_branding Trivalent
 %global chromium_path %{_libdir}/%{chromium_name}
 
+%global with_selinux 1
+%global modulename %{chromium_name}
+%global selinuxtype targeted
+
 # To generate this list, go into %%{buildroot}%%{chromium_path} and run
 # for i in `find . -name "*.so" | sort`; do NAME=`basename -s .so $i`; printf "$NAME|"; done
 %global __provides_exclude_from ^(%{chromium_path}/.*\\.so|%{chromium_path}/.*\\.so.*)$
@@ -78,6 +82,10 @@ Source18: %{chromium_name}256.png
 
 #Source19: %{chromium_name}22-text.png
 #Source20: %{chromium_name}22-text-white.png
+
+Source21: %{chromium_name}.fc
+Source22: %{chromium_name}.if
+Source23: %{chromium_name}.te
 
 ### Patches ###
 %{lua:
@@ -208,6 +216,12 @@ BuildRequires: nodejs
 %global build_target() \
 	export NINJA_STATUS="[%2:%f/%t] " ; \
 	ninja -j %{numjobs} -C '%1' '%2'
+%endif
+
+%if 0%{?with_selinux}
+BuildRequires:  make
+BuildRequires:  selinux-policy-devel
+Recommends:     (%{name}-selinux if selinux-policy-%{selinuxtype})
 %endif
 
 Requires: nss%{_isa} >= 3.26
@@ -367,13 +381,6 @@ Provides: bundled(zstd)
 %description
 %{chromium_name_branding} is a security-focused browser built upon the Chromium web browser.
 
-%package qt6-ui
-Summary: Qt6 UI built from %{chromium_name_branding}
-Requires: %{chromium_name}%{_isa} = %{version}-%{release}
-
-%description qt6-ui
-Qt6 UI for %{chromium_name_branding}.
-
 %prep
 %setup -q -n chromium-%{version}
 
@@ -446,6 +453,11 @@ ln -s $(which node) third_party/node/linux/node-linux-x64/bin/node
 
 # Hard code extra version
 sed -i 's/getenv("CHROME_VERSION_EXTRA")/"%{chromium_name}"/' chrome/common/channel_info_posix.cc
+
+%if 0%{?with_selinux}
+mkdir -p selinux
+cp -a %{SOURCE21} %{SOURCE22} %{SOURCE23} selinux
+%endif
 
 %build
 # reduce warnings
@@ -546,6 +558,11 @@ gn --script-executable=%{__python3} gen --args="$CHROMIUM_GN_DEFINES" %{chromebu
 %{__python3} $SOURCE_DIR/depot_tools/autoninja.py -C %{chromebuilddir} chrome
 %endif
 
+%if 0%{?with_selinux}
+make -f %{_datadir}/selinux/devel/Makefile %{modulename}.pp
+bzip2 -9 %{modulename}.pp
+%endif
+
 %install
 rm -rf %{buildroot}
 
@@ -618,6 +635,11 @@ appstream-util validate-relax --nonet ${RPM_BUILD_ROOT}%{_datadir}/metainfo/%{ch
 mkdir -p %{buildroot}%{_datadir}/gnome-control-center/default-apps/
 cp -a %{SOURCE9} %{buildroot}%{_datadir}/gnome-control-center/default-apps/
 
+%if 0%{?with_selinux}
+install -Dp -m 0644 -t %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype} %{modulename}.pp.bz2
+install -Dp -m 0644 -t %{buildroot}%{_datadir}/selinux/devel/include/distributed selinux/%{modulename}.if
+%endif
+
 %post
 # Set SELinux labels - semanage itself will adjust the lib directory naming
 # But only do it when selinux is enabled, otherwise, it gets noisy.
@@ -626,9 +648,6 @@ if selinuxenabled; then
 	semanage fcontext -a -t bin_t /usr/lib/%{chromium_name}/%{chromium_name}.sh &>/dev/null || :
 	restorecon -R -v %{chromium_path}/%{chromium_name} &>/dev/null || :
 fi
-
-%files qt6-ui
-%{chromium_path}/libqt6_shim.so
 
 %files
 %doc AUTHORS
@@ -662,3 +681,49 @@ fi
 %dir %{chromium_path}/locales/
 %{chromium_path}/locales/*.pak
 
+%package qt6-ui
+Summary: Qt6 UI built from %{chromium_name_branding}
+Requires: %{chromium_name}%{_isa} = %{version}-%{release}
+
+%description qt6-ui
+Qt6 UI for %{chromium_name_branding}.
+
+%files qt6-ui
+%{chromium_path}/libqt6_shim.so
+
+%if 0%{?with_selinux}
+%package selinux
+Summary:        SELinux policies for %{chromium_name_branding}
+License:        Apache-2.0 OR MIT
+
+Requires:       %{name}
+Requires:       selinux-policy-%{selinuxtype}
+Requires(post): selinux-policy-%{selinuxtype}
+BuildArch:      noarch
+%{?selinux_requires_min}
+
+%description selinux
+SELinux policy modules for %{chromium_name_branding}.
+
+%pre selinux
+%selinux_relabel_pre -s %{selinuxtype}
+
+%post selinux
+%selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.bz2
+
+%postun selinux
+if [ "$1" -eq 0 ]; then
+    %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
+    %selinux_relabel_post -s %{selinuxtype}
+fi
+
+%posttrans selinux
+%selinux_relabel_post -s %{selinuxtype}
+
+%files selinux
+%{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.*
+%{_datadir}/selinux/devel/include/distributed/%{modulename}.if
+%ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}
+
+# if with_selinux
+%endif

--- a/build/trivalent.te
+++ b/build/trivalent.te
@@ -1,0 +1,387 @@
+policy_module(trivalent, 1.0.0)
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+########################################
+#
+# Declarations
+#
+
+## <desc>
+## <p>
+## Allow chromium to read/write/map v4l devices
+## </p>
+## <p>
+## Needed for camera access
+## </p>
+## </desc>
+gen_tunable(trivalent_rwmap_video_dev, true)
+
+attribute_role trivalent_roles;
+
+attribute trivalent_domain;
+attribute trivalent_script_domain;
+
+type trivalent_exec_t;
+application_executable_file(trivalent_exec_t)
+
+type trivalent_home_t;
+userdom_user_home_content(trivalent_home_t)
+
+type trivalent_script_exec_t;
+application_executable_file(trivalent_script_exec_t)
+
+
+##############################
+#
+# Local policy
+#
+
+gen_require(`
+	attribute userdomain;
+	class dbus acquire_svc;
+	type audio_home_t;
+	type chrome_sandbox_home_t;
+	type device_t;
+	type dosfs_t;
+	type fonts_cache_t;
+	type http_port_t;
+	type http_cache_port_t;
+	type howl_port_t;
+	type ld_so_cache_t;
+	type null_device_t;
+	type root_t;
+	type pki_ca_port_t;
+	type nsfs_t;
+	type tmp_t;
+	type tmpfs_t;
+	type user_home_t;
+	type xserver_misc_device_t;
+')
+
+trivalent_filetrans_home_content(userdomain)
+trivalent_filetrans_home_content(trivalent_domain)
+trivalent_filetrans_home_content(trivalent_script_domain)
+
+# internal
+allow trivalent_domain self:process { execmem getcap getsched setcap setrlimit setsched sigkill signal signull };
+tunable_policy(`deny_ptrace',`',`
+	allow trivalent_domain self:process ptrace;
+')
+allow trivalent_domain self:dir { manage_dir_perms };
+allow trivalent_domain self:file { manage_file_perms execute map };
+allow trivalent_domain self:lnk_file { manage_lnk_file_perms };
+allow trivalent_domain self:fifo_file rw_fifo_file_perms;
+allow trivalent_domain self:sem create_sem_perms;
+allow trivalent_domain self:netlink_kobject_uevent_socket client_stream_socket_perms;
+allow trivalent_domain self:user_namespace create;
+allow trivalent_domain self:unix_stream_socket { connectto rw_socket_perms };
+allow trivalent_domain self:cap_userns { sys_admin sys_chroot sys_ptrace net_admin };
+allow trivalent_domain self:fifo_file { manage_fifo_file_perms relabelfrom relabelto };
+allow trivalent_domain self:dir rw_dir_perms;
+allow trivalent_domain self:socket_class_set create_socket_perms;
+allow trivalent_domain self:tcp_socket { accept listen };
+allow trivalent_domain trivalent_exec_t:file execute_no_trans;
+allow trivalent_domain chrome_sandbox_home_t:dir { manage_dir_perms };
+allow trivalent_domain chrome_sandbox_home_t:file { manage_file_perms execute map };
+allow trivalent_domain chrome_sandbox_home_t:lnk_file { manage_lnk_file_perms };
+allow trivalent_domain trivalent_home_t:dir { manage_dir_perms };
+allow trivalent_domain trivalent_home_t:file { manage_file_perms execute map };
+allow trivalent_domain trivalent_home_t:lnk_file { manage_lnk_file_perms };
+allow trivalent_domain self:netlink_route_socket { nlmsg_read nlmsg_write };
+
+# not covered by interfaces
+allow trivalent_domain fonts_cache_t:dir mounton;
+allow trivalent_domain howl_port_t:udp_socket name_bind;
+allow trivalent_domain http_port_t:tcp_socket { name_connect };
+allow trivalent_domain http_cache_port_t:tcp_socket { name_connect };
+allow trivalent_domain pki_ca_port_t:tcp_socket name_connect;
+allow trivalent_domain root_t:dir mounton;
+allow trivalent_domain tmp_t:lnk_file { create unlink };
+allow trivalent_domain tmp_t:sock_file { create unlink };
+allow trivalent_domain tmp_t:dir mounton;
+allow trivalent_domain tmpfs_t:file mounton;
+allow trivalent_domain tmpfs_t:dir { create };
+
+# required for trivalent to be able to detect whether it's the default browser
+allow trivalent_domain trivalent_script_exec_t:file { execute getattr read execute_no_trans ioctl open };
+
+# homedir access
+allow trivalent_domain user_home_t:dir { manage_dir_perms };
+allow trivalent_domain user_home_t:file { manage_file_perms };
+allow trivalent_domain user_home_t:lnk_file { manage_lnk_file_perms };
+allow trivalent_domain audio_home_t:dir { manage_dir_perms };
+allow trivalent_domain audio_home_t:file { manage_file_perms };
+allow trivalent_domain audio_home_t:lnk_file { manage_lnk_file_perms };
+
+optional_policy(`
+	gen_require(`
+		attribute file_manager_type;
+	')
+
+	# required for trivalent/FM clipboard sharing
+	allow trivalent_domain file_manager_type:fifo_file write;
+')
+
+# allow trivalent to interface with flatpaks (necessary for keepassxc extension, for example)
+# uncomment this once new flatpak policy is in use
+# optional_policy(`
+# 	flatpak_read_apps(trivalent_domain)
+# 	flatpak_exec_apps(trivalent_domain)
+# ')
+allow trivalent_domain data_home_t:file { execute execute_no_trans };
+
+# allow trivalent to own its mpris daemon
+dbus_connect_session_bus(trivalent_domain)
+
+# xwayland/nvidia
+xserver_exec(trivalent_domain)
+dev_rw_xserver_misc(trivalent_domain)
+dev_map_xserver_misc(trivalent_domain)
+allow trivalent_domain xserver_misc_device_t:chr_file { getattr ioctl map open read write };
+xserver_stream_connect_xdm(trivalent_domain)
+xserver_stream_connect(trivalent_domain)
+
+files_list_home(trivalent_domain)
+files_search_home(trivalent_domain)
+files_read_usr_files(trivalent_domain)
+files_read_etc_files(trivalent_domain)
+files_read_etc_runtime_files(trivalent_domain)
+files_watch_etc_dirs(trivalent_domain)
+files_getattr_all_dirs(trivalent_domain)
+files_watch_root_dirs(trivalent_domain)
+files_read_var_lib_files(trivalent_domain)
+files_rw_generic_tmp_dir(trivalent_domain)
+files_manage_generic_tmp_files(trivalent_domain)
+files_manage_generic_tmp_dirs(trivalent_domain)
+files_rw_generic_tmp_sockets(trivalent_domain)
+files_rw_tmp_file_leaks(trivalent_domain)
+files_map_generic_tmp_files(trivalent_domain)
+
+# copy/pasting to distrobox apps
+container_spc_rw_pipes(trivalent_domain)
+
+# memory pressure
+kernel_read_psi(trivalent_domain)
+kernel_read_kernel_sysctls(trivalent_domain)
+kernel_read_fs_sysctls(trivalent_domain)
+
+# required to connect to wayland
+dbus_system_bus_client(trivalent_domain)
+dbus_session_bus_client(trivalent_domain)
+
+dbus_write_session_tmp_sock_files(trivalent_domain)
+devicekit_dbus_chat_disk(trivalent_domain)
+devicekit_dbus_chat_power(trivalent_domain)
+systemd_dbus_chat_hostnamed(trivalent_domain)
+
+fs_rw_inherited_tmpfs_files(trivalent_domain)
+fs_getattr_xattr_fs(trivalent_domain)
+fs_getattr_tmpfs(trivalent_domain)
+fs_manage_tmpfs_files(trivalent_domain)
+fs_map_tmpfs_files(trivalent_domain)
+fs_search_cgroup_dirs(trivalent_domain)
+fs_associate_proc(trivalent_domain)
+fs_unmount_tmpfs(trivalent_domain)
+fs_mount_tmpfs(trivalent_domain)
+fs_remount_tmpfs(trivalent_domain)
+fs_manage_tmpfs_symlinks(trivalent_domain)
+fs_all_mount_fs_perms_xattr_fs(trivalent_domain)
+fs_mounton_tmpfs(trivalent_domain)
+
+miscfiles_read_all_certs(trivalent_domain)
+miscfiles_map_generic_certs(trivalent_domain)
+miscfiles_read_localization(trivalent_domain)
+miscfiles_watch_localization_dirs(trivalent_domain)
+miscfiles_read_hwdata(trivalent_domain)
+
+alsa_read_rw_config(trivalent_domain)
+pulseaudio_stream_connect(trivalent_domain)
+pulseaudio_read_home_files(trivalent_domain)
+cups_read_config(trivalent_domain)
+cups_stream_connect(trivalent_domain)
+
+dev_read_sysfs(trivalent_domain)
+dev_rw_dma_dev(trivalent_domain)
+dev_rw_dri(trivalent_domain)
+dev_rw_generic_usb_dev(trivalent_domain)
+dev_read_sound(trivalent_domain)
+dev_write_sound(trivalent_domain)
+dev_read_urand(trivalent_domain)
+dev_read_rand(trivalent_domain)
+
+tunable_policy(`trivalent_rwmap_video_dev', `
+	dev_read_video_dev(trivalent_domain)
+	dev_write_video_dev(trivalent_domain)
+	dev_map_video_dev(trivalent_domain)
+')
+
+udev_read_pid_files(trivalent_domain)
+term_mount_pty_fs(trivalent_domain)
+
+gnome_search_gconf_data_dir(trivalent_domain)
+gnome_manage_cache_home_dir(trivalent_domain)
+gnome_manage_generic_cache_files(trivalent_domain)
+gnome_manage_generic_cache_sockets(trivalent_domain)
+gnome_map_generic_cache_files(trivalent_domain)
+gnome_manage_home_config(trivalent_domain)
+gnome_exec_config_home_files(trivalent_domain)
+gnome_manage_home_config_dirs(trivalent_domain)
+gnome_manage_data(trivalent_domain)
+gnome_manage_generic_home_files(trivalent_domain)
+gnome_manage_generic_home_dirs(trivalent_domain)
+gnome_map_generic_data_home_files(trivalent_domain)
+gnome_manage_gstreamer_home_files(trivalent_domain)
+gnome_dbus_chat_gconfdefault(trivalent_domain)
+gnome_dbus_chat_gkeyringd(trivalent_domain)
+
+userdom_manage_user_tmp_sockets(trivalent_domain)
+userdom_manage_user_tmp_files(trivalent_domain)
+userdom_map_tmp_files(trivalent_domain)
+userdom_manage_tmpfs_files(trivalent_domain)
+userdom_read_inherited_user_tmp_files(trivalent_domain)
+userdom_manage_home_certs(trivalent_domain)
+userdom_use_user_terminals(trivalent_domain)
+userdom_list_user_home_dirs(trivalent_domain)
+
+logging_write_journal_files(trivalent_domain)
+logging_write_syslog_pid_socket(trivalent_domain)
+
+auth_read_passwd_file(trivalent_domain)
+
+# needed to be able to xdg-open, which is bin_t
+corecmd_exec_bin(trivalent_domain)
+
+pcscd_stream_connect(trivalent_domain)
+xserver_use_user_fonts(trivalent_domain)
+xserver_map_user_fonts(trivalent_domain)
+
+systemd_dbus_chat_hostnamed(trivalent_domain)
+systemd_resolved_watch_pid_dirs(trivalent_domain)
+init_search_pid_dirs(trivalent_domain)
+init_read_state(trivalent_domain)
+
+corenet_tcp_connect_all_unreserved_ports(trivalent_domain)
+corenet_tcp_connect_generic_port(trivalent_domain)
+corenet_tcp_connect_ftp_port(trivalent_domain)
+corenet_tcp_connect_http_port(trivalent_domain)
+corenet_tcp_connect_ipp_port(trivalent_domain)
+corenet_tcp_bind_generic_node(trivalent_domain)
+corenet_udp_bind_generic_node(trivalent_domain)
+corenet_udp_bind_all_unreserved_ports(trivalent_domain)
+sysnet_read_config(trivalent_domain)
+sysnet_dns_name_resolve(trivalent_domain)
+networkmanager_dbus_chat(trivalent_domain)
+
+storage_getattr_fixed_disk_dev(trivalent_domain)
+
+optional_policy(`
+	bluetooth_dbus_chat(trivalent_domain)
+')
+
+allow trivalent_script_domain trivalent_domain:dir { getattr search };
+allow trivalent_script_domain trivalent_domain:file { open read };
+allow trivalent_script_domain self:dir { add_entry_dir_perms };
+allow trivalent_script_domain self:file { create };
+allow trivalent_script_domain self:user_namespace create;
+allow trivalent_script_domain self:cap_userns { sys_ptrace sys_admin setpcap };
+allow trivalent_script_domain self:process { setcap setsched };
+tunable_policy(`deny_ptrace',`',`
+	allow trivalent_script_domain self:process ptrace;
+')
+allow trivalent_script_domain user_home_t:dir { search };
+allow trivalent_script_domain cache_home_t:dir { mounton };
+allow trivalent_script_domain chrome_sandbox_home_t:dir { manage_dir_perms };
+allow trivalent_script_domain chrome_sandbox_home_t:file { manage_file_perms };
+allow trivalent_script_domain chrome_sandbox_home_t:lnk_file read;
+allow trivalent_script_domain trivalent_home_t:dir { manage_dir_perms };
+allow trivalent_script_domain trivalent_home_t:file { manage_file_perms map };
+allow trivalent_script_domain trivalent_home_t:lnk_file { manage_lnk_file_perms };
+allow trivalent_script_domain nsfs_t:file getattr;
+allow trivalent_script_domain ld_so_cache_t:file mounton;
+allow trivalent_script_domain root_t:dir mounton;
+allow trivalent_script_domain tmp_t:dir mounton;
+allow trivalent_script_domain tmp_t:sock_file getattr;
+allow trivalent_script_domain tmpfs_t:dir { create };
+allow trivalent_script_domain device_t:filesystem remount;
+allow trivalent_script_domain dosfs_t:filesystem remount;
+allow trivalent_script_domain null_device_t:chr_file mounton;
+
+# xwayland/nvidia
+xserver_exec(trivalent_script_domain)
+dev_rw_xserver_misc(trivalent_script_domain)
+dev_map_xserver_misc(trivalent_script_domain)
+allow trivalent_script_domain xserver_misc_device_t:chr_file { getattr ioctl map open read write };
+
+domain_dontaudit_search_all_domains_state(trivalent_script_domain)
+files_manage_generic_tmp_dirs(trivalent_script_domain)
+fs_mounton_tmpfs(trivalent_script_domain)
+fs_unmount_tmpfs(trivalent_script_domain)
+fs_mount_tmpfs(trivalent_script_domain)
+gnome_manage_data(trivalent_script_domain)
+gnome_manage_home_config(trivalent_script_domain)
+gnome_manage_home_config_dirs(trivalent_script_domain)
+gnome_manage_cache_home_dir(trivalent_script_domain)
+gnome_manage_generic_cache_files(trivalent_script_domain)
+gnome_manage_generic_cache_sockets(trivalent_script_domain)
+gnome_map_generic_cache_files(trivalent_script_domain)
+corecmd_exec_shell(trivalent_script_domain)
+corecmd_exec_bin(trivalent_script_domain)
+files_getattr_all_dirs(trivalent_script_domain)
+userdom_list_user_home_dirs(trivalent_script_domain)
+kernel_list_proc(trivalent_script_domain)
+kernel_read_proc_files(trivalent_script_domain)
+kernel_getattr_proc_files(trivalent_script_domain)
+kernel_getattr_proc(trivalent_script_domain)
+seutil_exec_setfiles(trivalent_script_domain)
+seutil_manage_file_contexts(trivalent_script_domain)
+userdom_use_inherited_user_terminals(trivalent_script_domain)
+fs_all_mount_fs_perms_xattr_fs(trivalent_script_domain)
+
+optional_policy(`
+	gen_require(`
+		type unconfined_t;
+		role unconfined_r;
+	')
+
+	trivalent_role_template(unconfined, unconfined_r, unconfined_t)
+')
+
+optional_policy(`
+	gen_require(`
+		type flatpak_t;
+    type unconfined_trivalent_script_t;
+	')
+
+	domtrans_pattern(flatpak_t, trivalent_script_exec_t, unconfined_trivalent_script_t)
+')
+
+
+optional_policy(`
+	gen_require(`
+		type sysadm_t;
+		role sysadm_r;
+	')
+
+	trivalent_role_template(sysadm, sysadm_r, sysadm_t)
+')
+
+optional_policy(`
+	gen_require(`
+		type staff_t;
+		role staff_r;
+	')
+
+	trivalent_role_template(staff, staff_r, staff_t)
+')
+
+optional_policy(`
+	gen_require(`
+		type user_t;
+		role user_r;
+	')
+
+	trivalent_role_template(user, user_r, user_t)
+')


### PR DESCRIPTION
The policy itself is copied unmodified from the secureblue repo. This should allow Trivalent's SELinux policy to be installed as an RPM on secureblue or any other RPM-based distro.