### PR TITLE
fix(aarch64): disable cflag unsupported on clang21

### DIFF
--- a/fedora_patches/disable-cflag-for-aarch64-builds.patch
+++ b/fedora_patches/disable-cflag-for-aarch64-builds.patch
@@ -1,0 +1,23 @@
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index 3caedebb1d279..dd384a47f73e0 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -1855,18 +1855,6 @@ config("sanitize_c_array_bounds") {
+     cflags = [
+       "-fsanitize=array-bounds",
+       "-fsanitize-trap=array-bounds",
+-
+-      # Some code users feature detection to determine if UBSAN (or any
+-      # sanitizer) is enabled, they then do expensive debug like operations. We
+-      # want to suppress this behaviour since we want to keep performance costs
+-      # as low as possible while having these checks.
+-      "-fsanitize-ignore-for-ubsan-feature=array-bounds",
+-
+-      # Because we've enabled array-bounds sanitizing we also want to suppress
+-      # the related warning about "unsafe-buffer-usage-in-static-sized-array",
+-      # since we know that the array bounds sanitizing will catch any out-of-
+-      # bounds accesses.
+-      "-Wno-unsafe-buffer-usage-in-static-sized-array",
+     ]
+   }
+ }


### PR DESCRIPTION
https://chromium-review.googlesource.com/c/chromium/src/+/7539408/6/build/config/compiler/BUILD.gn