### PR TITLE
fix(selinux): improve container-selinux dependency handling

### DIFF
--- a/build/trivalent.spec
+++ b/build/trivalent.spec
@@ -692,6 +692,7 @@ License:        Apache-2.0 OR MIT
 Requires:       %{name}
 Requires:       selinux-policy-%{selinuxtype}
 Requires(post): selinux-policy-%{selinuxtype}
+Recommends:     container-selinux
 BuildArch:      noarch
 %{?selinux_requires_min}
 

--- a/build/trivalent.te
+++ b/build/trivalent.te
@@ -160,9 +160,6 @@ files_rw_generic_tmp_sockets(trivalent_domain)
 files_rw_tmp_file_leaks(trivalent_domain)
 files_map_generic_tmp_files(trivalent_domain)
 
-# copy/pasting to distrobox apps
-container_spc_rw_pipes(trivalent_domain)
-
 # memory pressure
 kernel_read_psi(trivalent_domain)
 kernel_read_kernel_sysctls(trivalent_domain)
@@ -279,6 +276,11 @@ storage_getattr_fixed_disk_dev(trivalent_domain)
 
 optional_policy(`
 	bluetooth_dbus_chat(trivalent_domain)
+')
+
+optional_policy(`
+	# copy/pasting to distrobox apps
+	container_spc_rw_pipes(trivalent_domain)
 ')
 
 allow trivalent_script_domain trivalent_domain:dir { getattr search };


### PR DESCRIPTION
Mark `container-selinux` as a weak runtime dependency, and wrap the use of a container interface in `optional_policy` so the policy can still be installed in the absence of the `container-selinux` package.