### PR TITLE
chore: bump fedora containers to 44

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     if: github.triggering_actor == 'royaloughtness'
     runs-on: ${{ inputs.arch == 'x86_64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     container:
-      image: ${{ inputs.arch == 'x86_64' && 'fedora:43@sha256:b8f499bee9c97c7c1be0ff7b8b6e4ab72af4216c30d2365c9d474ce2d5c5fd9a' || 'fedora:43@sha256:b5bf856429ce79986e9d80bf58766f6d5b7fad6dab717314539cb7cd0e280f45' }}
+      image: ${{ inputs.arch == 'x86_64' && 'fedora:44@sha256:f717d3f59ea0dc45d3c024c9477e786bab7d418d26636920d17b48016f1e69ca' || 'fedora:44@sha256:63a832c5308c808ecee9a90a0459f67beee9205db01bd967bde410429cd33fc0' }}
     steps:
       - name: Enable egress auditing
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -79,7 +79,7 @@ jobs:
     needs: buildsrpm
     runs-on: ${{ inputs.arch == 'x86_64' && 'runs-on=${{ github.run_id }}/runner=x86_64-runner' || 'runs-on=${{ github.run_id }}/runner=arm64-runner' }}
     container:
-      image: ${{ inputs.arch == 'x86_64' && 'fedora:43@sha256:b8f499bee9c97c7c1be0ff7b8b6e4ab72af4216c30d2365c9d474ce2d5c5fd9a' || 'fedora:43@sha256:b5bf856429ce79986e9d80bf58766f6d5b7fad6dab717314539cb7cd0e280f45' }}
+      image: ${{ inputs.arch == 'x86_64' && 'fedora:44@sha256:f717d3f59ea0dc45d3c024c9477e786bab7d418d26636920d17b48016f1e69ca' || 'fedora:44@sha256:63a832c5308c808ecee9a90a0459f67beee9205db01bd967bde410429cd33fc0' }}
       options: --privileged
     steps:
       - name: Enable egress auditing
@@ -136,7 +136,7 @@ jobs:
     environment: ${{ inputs.test_build && 'TestBuild' || 'Build' }}
     runs-on: ${{ inputs.arch == 'x86_64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     container:
-      image: ${{ inputs.arch == 'x86_64' && 'fedora:43@sha256:b8f499bee9c97c7c1be0ff7b8b6e4ab72af4216c30d2365c9d474ce2d5c5fd9a' || 'fedora:43@sha256:b5bf856429ce79986e9d80bf58766f6d5b7fad6dab717314539cb7cd0e280f45' }}
+      image: ${{ inputs.arch == 'x86_64' && 'fedora:44@sha256:f717d3f59ea0dc45d3c024c9477e786bab7d418d26636920d17b48016f1e69ca' || 'fedora:44@sha256:63a832c5308c808ecee9a90a0459f67beee9205db01bd967bde410429cd33fc0' }}
     needs: buildrpm
     outputs:
       hashes: ${{ steps.sign.outputs.hashes }}


### PR DESCRIPTION
https://hub.docker.com/layers/library/fedora/44/images/sha256-f717d3f59ea0dc45d3c024c9477e786bab7d418d26636920d17b48016f1e69ca