### PR TITLE
fix: respect XDG_CACHE_HOME instead of hardcoding $HOME/.cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       image: ${{ inputs.arch == 'x86_64' && 'fedora:44@sha256:f717d3f59ea0dc45d3c024c9477e786bab7d418d26636920d17b48016f1e69ca' || 'fedora:44@sha256:63a832c5308c808ecee9a90a0459f67beee9205db01bd967bde410429cd33fc0' }}
     steps:
       - name: Enable egress auditing
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
@@ -94,7 +94,7 @@ jobs:
       options: --privileged
     steps:
       - name: Enable egress auditing
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
@@ -152,7 +152,7 @@ jobs:
       hashes: ${{ steps.sign.outputs.hashes }}
     steps:
       - name: Enable egress auditing
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 

--- a/build/install/trivalent.sh
+++ b/build/install/trivalent.sh
@@ -113,7 +113,7 @@ BWRAP_ARGS+=" --cap-drop ALL" # if the browser has capabilities, that is very co
 if [[ -r "/etc/ld.so.preload" ]]; then # if the file doesnt exist, bwrap will error out
   BWRAP_ARGS+=" --ro-bind-try /dev/null /etc/ld.so.preload" # avoid ld preload usage
 fi
-BWRAP_ARGS+=" --bind ${TMPFS_CACHE_DIR} ${HOME}/.cache" # avoid issues with other applications messing with cache
+BWRAP_ARGS+=" --bind ${TMPFS_CACHE_DIR} ${XDG_CACHE_HOME:-$HOME/.cache}" # avoid issues with other applications messing with cache
 BWRAP_ARGS+=" --setenv GDK_DISABLE icon-nodes" # avoid issues with glycin
 
 # Do this at the end so that everything else still gets hardened_malloc


### PR DESCRIPTION
I have set the XDG_CACHE_HOME environment variable to a location different than the default value of $HOME/.cache. For some odd reason, when trying to launch Trivalent with this configuration by using the provided trivalent.sh script on a vanilla Fedora installition, it fails to launch if $HOME/.cache doesn't exist. The following error gets printed to stdout/stderr:

```
bwrap: Can't mkdir /home/MYUSER/.cache: Permission denied
```

Creating that directory manually and rerunning the script makes Trivalent launch just fine, even though it doesn't create any temp files in that directory.

I then copied the script from /usr/bin/trivalent to another directory and modified it such that it could be executed from this new location, and for whatever reason, it now launched just fine after having automatically created the hidden cache directory on my home folder.

Anyhow, we shouldn't assume that the cache directory is located at $HOME/.cache on each system, since the XDG spec allows moving its location via the XDG_CACHE_HOME env variable. Using XDG_CACHE_HOME would fix both of the issues mentioned above, i.e. allowing Trivalent to run with a custom cache directory location and in some cases, not creating a new cache directory at the wrong location. As per the spec, we should however [default to the old directory in case XDG_CACHE_HOME isn't set.](https://specifications.freedesktop.org/basedir/latest/)