### PR TITLE
chore: replace JIT site setting text to be more accurate

### DIFF
--- a/patches/trivalent/ui/adjust-prefs-text.patch
+++ b/patches/trivalent/ui/adjust-prefs-text.patch
@@ -93,3 +93,28 @@ index d989c90598e38..985a47c20c397 100644
  </div>
  <template is="dom-if" if="[[showManagedHeader_(inSearchMode_, lastRoute_)]]"
      restamp>
+diff --git a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+index b8170f520a..9732670e2e 100644
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -3051,7 +3051,7 @@ void AddSiteSettingsStrings(content::WebUIDataSource* html_source,
+       {"siteSettingsCategoryLocation", IDS_SITE_SETTINGS_TYPE_LOCATION},
+       {"siteSettingsCategoryJavascript", IDS_SITE_SETTINGS_TYPE_JAVASCRIPT},
+       {"siteSettingsCategoryJavascriptOptimizer",
+-       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},
++       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},
+       {"siteSettingsCategoryMicrophone", IDS_SITE_SETTINGS_TYPE_MIC},
+       {"siteSettingsMicrophoneLabel", IDS_SITE_SETTINGS_TYPE_MIC},
+       {"siteSettingsCategoryNotifications",
+@@ -3140,9 +3140,9 @@ void AddSiteSettingsStrings(content::WebUIDataSource* html_source,
+       {"siteSettingsJavascriptMidSentence",
+        IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_MID_SENTENCE},
+       {"siteSettingsJavascriptOptimizer",
+-       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},
++       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},
+       {"siteSettingsJavascriptOptimizerMidsentence",
+-       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},  // Deliberately the same
++       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},  // Deliberately the same
+                                                       // form.
+       {"siteSettingsSound", IDS_SITE_SETTINGS_TYPE_SOUND},
+       {"siteSettingsSoundMidSentence",

--- a/patches/trivalent/ui/adjust-prefs-text.patch
+++ b/patches/trivalent/ui/adjust-prefs-text.patch
@@ -93,28 +93,3 @@ index d989c90598e38..985a47c20c397 100644
  </div>
  <template is="dom-if" if="[[showManagedHeader_(inSearchMode_, lastRoute_)]]"
      restamp>
-diff --git a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-index b8170f520a..9732670e2e 100644
---- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-+++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -3051,7 +3051,7 @@ void AddSiteSettingsStrings(content::WebUIDataSource* html_source,
-       {"siteSettingsCategoryLocation", IDS_SITE_SETTINGS_TYPE_LOCATION},
-       {"siteSettingsCategoryJavascript", IDS_SITE_SETTINGS_TYPE_JAVASCRIPT},
-       {"siteSettingsCategoryJavascriptOptimizer",
--       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},
-+       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},
-       {"siteSettingsCategoryMicrophone", IDS_SITE_SETTINGS_TYPE_MIC},
-       {"siteSettingsMicrophoneLabel", IDS_SITE_SETTINGS_TYPE_MIC},
-       {"siteSettingsCategoryNotifications",
-@@ -3140,9 +3140,9 @@ void AddSiteSettingsStrings(content::WebUIDataSource* html_source,
-       {"siteSettingsJavascriptMidSentence",
-        IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_MID_SENTENCE},
-       {"siteSettingsJavascriptOptimizer",
--       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},
-+       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},
-       {"siteSettingsJavascriptOptimizerMidsentence",
--       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},  // Deliberately the same
-+       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},  // Deliberately the same
-                                                       // form.
-       {"siteSettingsSound", IDS_SITE_SETTINGS_TYPE_SOUND},
-       {"siteSettingsSoundMidSentence",

--- a/patches/trivalent/ui/register-new-strings.patch
+++ b/patches/trivalent/ui/register-new-strings.patch
@@ -117,7 +117,7 @@ index 556a396168..a6547ce454 100644
        {"siteSettingsCategoryJavascript", IDS_SITE_SETTINGS_TYPE_JAVASCRIPT},
        {"siteSettingsCategoryJavascriptOptimizer",
 -       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},
-+       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},
++       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_JIT},
        {"siteSettingsCategoryMicrophone", IDS_SITE_SETTINGS_TYPE_MIC},
        {"siteSettingsMicrophoneLabel", IDS_SITE_SETTINGS_TYPE_MIC},
        {"siteSettingsCategoryNotifications",
@@ -126,10 +126,10 @@ index 556a396168..a6547ce454 100644
         IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_MID_SENTENCE},
        {"siteSettingsJavascriptOptimizer",
 -       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},
-+       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},
++       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_JIT},
        {"siteSettingsJavascriptOptimizerMidsentence",
 -       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},  // Deliberately the same
-+       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},  // Deliberately the same
++       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_JIT},  // Deliberately the same
                                                        // form.
        {"siteSettingsSound", IDS_SITE_SETTINGS_TYPE_SOUND},
        {"siteSettingsSoundMidSentence",

--- a/patches/trivalent/ui/register-new-strings.patch
+++ b/patches/trivalent/ui/register-new-strings.patch
@@ -10,11 +10,25 @@ Unless required by applicable law or agreed to in writing, software distributed 
 distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 ---
+diff --git a/components/site_settings_strings.grdp b/components/site_settings_strings.grdp
+index dbf4e88dbd..1e1746315b 100644
+--- a/components/site_settings_strings.grdp
++++ b/components/site_settings_strings.grdp
+@@ -124,6 +124,9 @@
+   <message name="IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER" desc="The label for the JavaScript optimizer site settings controls.">
+     JavaScript optimization &amp; security
+   </message>
++  <message name="IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_JIT" desc="Trivalent string.">
++    JavaScript JIT
++  </message>
+   <message name="IDS_SITE_SETTINGS_TYPE_LOCATION" desc="The label used for geolocation site settings controls." meaning="Geolocation">
+     Location
+   </message>
 diff --git a/chrome/app/settings_strings.grdp b/chrome/app/settings_strings.grdp
 index aae688f787..1ab79f7b31 100644
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1335,6 +1335,55 @@
+@@ -1335,6 +1335,52 @@
        Browsing and searching is faster than standard preloading
      </message>
  
@@ -63,9 +77,6 @@ index aae688f787..1ab79f7b31 100644
 +    <message name="IDS_DISABLE_EXTENSIONS_DESCRIPTION" desc="Trivalent String.">
 +      Changes to this setting requires a restart to apply
 +    </message>
-+    <message name="IDS_SITE_SETTINGS_JAVASCRIPT_JIT" desc="Trivalent String.">
-+      JavaScript JIT
-+    </message>
 +
      <!-- Privacy Page -->
      <message name="IDS_SETTINGS_PRIVACY" desc="Name of the settings page which allows users to modify privacy and security settings.">
@@ -101,6 +112,27 @@ index 556a396168..a6547ce454 100644
        {"privacyPageTitle", IDS_SETTINGS_PRIVACY},
        {"privacyPageMore", IDS_SETTINGS_PRIVACY_MORE},
        {"doNotTrack", IDS_SETTINGS_ENABLE_DO_NOT_TRACK},
+@@ -3051,7 +3051,7 @@ void AddSiteSettingsStrings(content::WebUIDataSource* html_source,
+       {"siteSettingsCategoryLocation", IDS_SITE_SETTINGS_TYPE_LOCATION},
+       {"siteSettingsCategoryJavascript", IDS_SITE_SETTINGS_TYPE_JAVASCRIPT},
+       {"siteSettingsCategoryJavascriptOptimizer",
+-       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},
++       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},
+       {"siteSettingsCategoryMicrophone", IDS_SITE_SETTINGS_TYPE_MIC},
+       {"siteSettingsMicrophoneLabel", IDS_SITE_SETTINGS_TYPE_MIC},
+       {"siteSettingsCategoryNotifications",
+@@ -3140,9 +3140,9 @@ void AddSiteSettingsStrings(content::WebUIDataSource* html_source,
+       {"siteSettingsJavascriptMidSentence",
+        IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_MID_SENTENCE},
+       {"siteSettingsJavascriptOptimizer",
+-       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},
++       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},
+       {"siteSettingsJavascriptOptimizerMidsentence",
+-       IDS_SITE_SETTINGS_TYPE_JAVASCRIPT_OPTIMIZER},  // Deliberately the same
++       IDS_SITE_SETTINGS_JAVASCRIPT_JIT},  // Deliberately the same
+                                                       // form.
+       {"siteSettingsSound", IDS_SITE_SETTINGS_TYPE_SOUND},
+       {"siteSettingsSoundMidSentence",
 @@ -3826,6 +3837,7 @@ void AddSiteDataPageStrings(content::WebUIDataSource* html_source,
  #if !BUILDFLAG(IS_CHROMEOS)
  void AddSystemStrings(content::WebUIDataSource* html_source) {

--- a/patches/trivalent/ui/register-new-strings.patch
+++ b/patches/trivalent/ui/register-new-strings.patch
@@ -14,7 +14,7 @@ diff --git a/chrome/app/settings_strings.grdp b/chrome/app/settings_strings.grdp
 index aae688f787..1ab79f7b31 100644
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1335,6 +1335,52 @@
+@@ -1335,6 +1335,55 @@
        Browsing and searching is faster than standard preloading
      </message>
  
@@ -62,6 +62,9 @@ index aae688f787..1ab79f7b31 100644
 +    </message>
 +    <message name="IDS_DISABLE_EXTENSIONS_DESCRIPTION" desc="Trivalent String.">
 +      Changes to this setting requires a restart to apply
++    </message>
++    <message name="IDS_SITE_SETTINGS_JAVASCRIPT_JIT" desc="Trivalent String.">
++      JavaScript JIT
 +    </message>
 +
      <!-- Privacy Page -->


### PR DESCRIPTION
Chromium upstream doesn't use the same preference to disable JS JIT, only optimizers. We disable JIT in whole.
This causes some confusion in regards to how our pref works and how it differs from the upstream pref. It also makes it easier for users to find the preference when told to disable or enable JIT for a site or extension.