### PR TITLE
fix: Make extensions "click-to-allow" by default

### DIFF
--- a/patches/trivalent/branding/trivalent-faq-page.patch
+++ b/patches/trivalent/branding/trivalent-faq-page.patch
@@ -203,8 +203,8 @@ new file mode 100644
 +    Trivalent's subresource filter cannot perform script injection or observe and alter what happens
 +    inside YouTube's video player, so it can't reliably intercept the scripts and dynamic behavior
 +    YouTube uses to serve ads. To avoid ads, you need a tool capable of doing that. Common options
-+    are <a href="https://flathub.org/apps/io.freetubeapp.FreeTube">FreeTube electron flatpak</a>,
-+    <a href="https://flathub.org/apps/de.schmidhuberj.tubefeeder">Pipeline piped proxy flatpak</a>,
++    are <a href="https://flathub.org/apps/io.freetubeapp.FreeTube">FreeTube Electron Flatpak</a>,
++    <a href="https://flathub.org/apps/de.schmidhuberj.tubefeeder">Pipeline Piped Proxy Flatpak</a>,
 +    and the YouTube PWA (progressive web-app) paired with uBlock Origin Lite. Consider creating a
 +    separate profile for the Youtube PWA, so you can continue browsing extensionless for your
 +    usual profile.<br>

--- a/patches/trivalent/branding/trivalent-faq-page.patch
+++ b/patches/trivalent/branding/trivalent-faq-page.patch
@@ -203,8 +203,8 @@ new file mode 100644
 +    Trivalent's subresource filter cannot perform script injection or observe and alter what happens
 +    inside YouTube's video player, so it can't reliably intercept the scripts and dynamic behavior
 +    YouTube uses to serve ads. To avoid ads, you need a tool capable of doing that. Common options
-+    are <a href="https://flathub.org/apps/io.freetubeapp.FreeTube">FreeTube Electron Flatpak</a>,
-+    <a href="https://flathub.org/apps/de.schmidhuberj.tubefeeder">Pipeline Piped proxy Flatpak</a>,
++    are <a href="https://flathub.org/apps/io.freetubeapp.FreeTube">FreeTube electron flatpak</a>,
++    <a href="https://flathub.org/apps/de.schmidhuberj.tubefeeder">Pipeline piped proxy flatpak</a>,
 +    and the YouTube PWA (progressive web-app) paired with uBlock Origin Lite. Consider creating a
 +    separate profile for the Youtube PWA, so you can continue browsing extensionless for your
 +    usual profile.<br>

--- a/patches/trivalent/security/set-extensions-click-to-allow.patch
+++ b/patches/trivalent/security/set-extensions-click-to-allow.patch
@@ -1,0 +1,24 @@
+Copyright 2024-2026 The Trivalent Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+---
+diff --git a/chrome/browser/extensions/extension_install_prompt.cc b/chrome/browser/extensions/extension_install_prompt.cc
+index 1234567..abcdefg 100644
+--- a/chrome/browser/extensions/extension_install_prompt.cc
++++ b/chrome/browser/extensions/extension_install_prompt.cc
+@@ -45,7 +45,7 @@ void ExtensionInstallPrompt::RegisterProfilePrefs(
+     user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(
+       prefs::kExtensionInstallationRequiresConsent,
+-      false,
++      true,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+ }

--- a/patches/trivalent/security/set-extensions-click-to-allow.patch
+++ b/patches/trivalent/security/set-extensions-click-to-allow.patch
@@ -1,4 +1,4 @@
-Copyright 2024-2026 The Trivalent Authors
+Copyright 2026 The Trivalent Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -10,15 +10,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 ---
-diff --git a/chrome/browser/extensions/extension_install_prompt.cc b/chrome/browser/extensions/extension_install_prompt.cc
-index 1234567..abcdefg 100644
---- a/chrome/browser/extensions/extension_install_prompt.cc
-+++ b/chrome/browser/extensions/extension_install_prompt.cc
-@@ -45,7 +45,7 @@ void ExtensionInstallPrompt::RegisterProfilePrefs(
-     user_prefs::PrefRegistrySyncable* registry) {
-   registry->RegisterBooleanPref(
-       prefs::kExtensionInstallationRequiresConsent,
--      false,
-+      true,
-       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
- }


### PR DESCRIPTION
Solve https://github.com/secureblue/Trivalent/issues/645



https://github.com/chromium/chromium/blob/main/chrome/browser/extensions/extension_context_menu_model.h
https://github.com/chromium/chromium/blob/main/chrome/browser/extensions/extension_context_menu_model.cc