### PR TITLE
feat: deny extension accesses by default

### DIFF
--- a/patches/trivalent/security/extension-access-hardening.patch
+++ b/patches/trivalent/security/extension-access-hardening.patch
@@ -1,0 +1,43 @@
+Copyright 2026 The Trivalent Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+---
+diff --git a/extensions/common/extension_features.cc b/extensions/common/extension_features.cc
+index 9342cb03e1..b74e67f440 100644
+--- a/extensions/common/extension_features.cc
++++ b/extensions/common/extension_features.cc
+@@ -86,7 +86,7 @@ BASE_FEATURE(kWebRequestSecurityInfo, base::FEATURE_DISABLED_BY_DEFAULT);
+ // For historical reasons, this includes some APIs. Please don't add more.
+ 
+ BASE_FEATURE(kAllowWithholdingExtensionPermissionsOnInstall,
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kCheckingNoExtensionIdInExtensionIpcs,
+              "EMF_NO_EXTENSION_ID_FOR_EXTENSION_SOURCE",
+@@ -227,7 +227,7 @@ BASE_FEATURE(kEnterpriseExtensionDOMActivityTelemetry,
+              base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kDebuggerAPIRestrictedToDevMode,
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kExtensionBrowserNamespaceAndPolyfillSupport,
+              base::FEATURE_ENABLED_BY_DEFAULT);
+@@ -256,7 +256,7 @@ BASE_FEATURE_PARAM(bool,
+                    true);
+ 
+ BASE_FEATURE(kSearchEngineUnconditionalDialog,
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kWebRequestPersistFilteredEventsViaEventRouter,
+              base::FEATURE_ENABLED_BY_DEFAULT);


### PR DESCRIPTION
Restricts access to permissionless site access (requires permission prompt), the debugger API (requires dev mode), and search engine controls (requires permission prompt)

Closes #645