### PR TITLE
chore: use /var/tmp instead of /tmp for cache isolation

### DIFF
--- a/build/install/trivalent.sh
+++ b/build/install/trivalent.sh
@@ -105,7 +105,7 @@ if [[ -f "/usr/lib64/trivalent/install_filter.sh" ]] ; then
   /bin/bash /usr/lib64/trivalent/install_filter.sh
 fi
 
-declare -r TMPFS_CACHE_DIR="/tmp/${CHROMIUM_NAME}_cache/"
+declare -r TMPFS_CACHE_DIR="/var/tmp/${CHROMIUM_NAME}_cache/"
 mkdir -p "$TMPFS_CACHE_DIR"
 
 declare -a BWRAP_ARGS=('--dev-bind' '/' '/')


### PR DESCRIPTION
Prevents rampant memory usage from font caches and such (roughly 6 mb) while still preserving caches in a temporary, separate location from standard xdg-cache.