### PR TITLE
fix(selinux): allow Trivalent to exec system flatpaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.xml]
+indent_size = 2
+
+[*.md]
+indent_size = 2
+
+[*.patch]
+trim_trailing_whitespace = false
+
+# SELinux
+[*.{fc,if,te}]
+indent_style = tab
+indent_size = 8
+
+[*.cil]
+indent_size = 2

--- a/build/selinux/trivalent.te
+++ b/build/selinux/trivalent.te
@@ -159,10 +159,14 @@ tunable_policy(`trivalent_exec_flatpaks', `
 		type data_home_t;
 		type flatpak_home_t;
 	')
+	# User flatpaks
 	exec_files_pattern(trivalent_domain, data_home_t, data_home_t)
 	read_lnk_files_pattern(trivalent_domain, data_home_t, data_home_t)
 	exec_files_pattern(trivalent_domain, flatpak_home_t, flatpak_home_t)
 	read_lnk_files_pattern(trivalent_domain, flatpak_home_t, flatpak_home_t)
+	# System flatpaks
+	exec_files_pattern(trivalent_domain, var_lib_t, var_lib_t)
+	read_lnk_files_pattern(trivalent_domain, var_lib_t, var_lib_t)
 ')
 
 tunable_policy(`trivalent_drm', `


### PR DESCRIPTION
System flatpak files are in `/var/lib/flatpak` and have type `var_lib_t` (this may be changed to a more specific type in the future). For example, this affects the ability of the KeepassXC extension to work in Trivalent if KeepassXC is installed as a system (rather than user) flatpak app.

Also add `.editorconfig` file to indicate file formatting conventions to text editors.