### PR TITLE
fix(docs): FAQ page string inaccuracy

### DIFF
--- a/patches/trivalent/branding/trivalent-faq-page.patch
+++ b/patches/trivalent/branding/trivalent-faq-page.patch
@@ -227,7 +227,7 @@ new file mode 100644
 +    Extensions in Trivalent are disabled by default, for security reasons, it is not advised to
 +    use them. If you want content/ad blocking, that is already built into Trivalent and enabled by
 +    default. If you require extensions, you can re-enable them by disabling the
-+    <code>Disable Extensions</code> toggle under
++    <code>Block Extensions</code> toggle under
 +    <a href="chrome://settings/security">chrome://settings/security</a>, then restarting your browser
 +    (this toggle is per-profile).
 +    <br><br>


### PR DESCRIPTION
In chrome://settings/security it says "Block extensions".