### PR TITLE
fix: use volume instead of disk for runs-on config

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -4,7 +4,7 @@ runners:
     ram: [128, 144, 192, 256, 384, 512]
     family: ["c5", "c6", "c7", "c8", "m5", "m6", "m7", "m8", "r6", "r7", "r8", "g4", "g5"]
     spot: price-capacity-optimized
-    disk: large
+    volume=80gb
     image: ubuntu24-stepsecurity-x64
     ssh: false
 
@@ -13,6 +13,6 @@ runners:
     ram: [128, 144, 192, 256, 384, 512]
     family: ["c5", "c6", "c7", "c8", "m5", "m6", "m7", "m8", "r6", "r7", "r8", "g4", "g5"]
     spot: price-capacity-optimized
-    disk: large
+    volume=80gb
     image: ubuntu24-stepsecurity-arm64
     ssh: false


### PR DESCRIPTION
https://runs-on.com/docs/runners/labels/#disk