### PR TITLE
fix: improper usage of this for security page

### DIFF
--- a/patches/trivalent/ui/adjust-security-and-privacy-page.patch
+++ b/patches/trivalent/ui/adjust-security-and-privacy-page.patch
@@ -217,7 +217,7 @@ index 6b9bd1adee..6e0bea5eee 100644
 +        <settings-dropdown-menu
 +          label="$i18n{webrtcHandlingPolicyLabel}"
 +          pref="{{prefs.webrtc.ip_handling_policy}}"
-+          .menuOptions="${this.webrtcHandlingPolicyOptions_}"
++          .menuOptions="[[webrtcHandlingPolicyOptions_]]"
 +        </settings-dropdown-menu>
 +      </div>
 +<if expr="is_linux or is_win">


### PR DESCRIPTION
The security page is not fully ported to the new UI handling framework