### PR TITLE
fix: build the dispatched commit rather than the branch tip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
         id: srpm_build
         env:
           BRANCH: ${{ github.ref_name }}
+          BUILD_SHA: ${{ github.sha }}
           CACHE_OVERRIDE_VERSION: ${{ inputs.override_version }}
         run: |
           dnf copr enable secureblue/trivalent -y
@@ -83,6 +84,7 @@ jobs:
           SOURCE_CACHE_HASH=$(sha256sum /usr/src/chromium/chromium-*.xz)
           echo "SOURCE_CACHE_HASH: ${SOURCE_CACHE_HASH}"
           git clone --branch "${BRANCH}" https://github.com/secureblue/Trivalent.git
+          git -C Trivalent checkout --detach "${BUILD_SHA}"
           bash ./Trivalent/copr_script.sh
           rpmbuild -bs -v --define "_sourcedir $PWD" --define "_rpmdir $PWD" --define "_builddir $PWD" --define "_specdir $PWD" --define "_srcrpmdir $PWD" trivalent.spec
           SRPM_HASH=$(sha256sum *.rpm)


### PR DESCRIPTION
Fixes an edgecase where the SLSA provenance that the `provenance` job attaches to each release can name a commit that is not the one the RPM was built from.

The build never pins the commit it builds from. It gets its source like this:

```yaml
env:
  BRANCH: ${{ github.ref_name }}
run: |
  git clone --branch "${BRANCH}" https://github.com/secureblue/Trivalent.git
```

Which asks for the branch, not the commit. Github already knows where `live` was when the run started (`github.sha`), and that is the commit the provenance names, but the clone ignores it and looks up `live` again when it runs. If a commit lands on `live` between the run starting and the clone running, that is what gets built, while the provenance still names the commit from when the run started. The clone sits after the `dnf` installs in the same step, so `live` is not read again until those finish.

For example on how long this window is, on run [30571405949](https://github.com/secureblue/Trivalent/actions/runs/30571405949), the clone ran at 18:42:26 UTC against a run start of 18:39:56, a 2.5 minute window. The window depends on how long the packages take to install that run though

This PR detaches the clone at `github.sha` so both point at the same commit.