### PR TITLE
fix: remove StartupWMClass from trivalent.desktop

### DIFF
--- a/build/install/trivalent.desktop
+++ b/build/install/trivalent.desktop
@@ -10,7 +10,6 @@ Type=Application
 Icon=trivalent
 Categories=Network;WebBrowser;
 MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;x-scheme-handler/http;x-scheme-handler/https;
-StartupWMClass=trivalent
 Keywords=web;browser;internet;
 Actions=new-window;new-private-window;
 


### PR DESCRIPTION
Setting `StartupWMClass` on the desktop launcher causes PWAs to be handled incorrectly by KDE Plasma: PWAs end up with Trivalent's icon intsead of their own icon, and are grouped with Trivalent instead of being treated as a separate app. Removing that line fixes these issues and doesn't seem to have any negative effects.

Fixes #851.